### PR TITLE
feat: [SEMIS-59] display attendance event

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
@@ -14,6 +14,7 @@ import org.saudigitus.semis.app.presentation.navigation.AppRoutes
 import org.saudigitus.semis.app.presentation.tei.TeiListEvent
 import org.saudigitus.semis.app.presentation.tei.TeiListScreen
 import org.saudigitus.semis.attendance.ui.AttendanceScreen
+import org.saudigitus.semis.attendance.ui.AttendanceUiEvent
 import org.saudigitus.semis.attendance.ui.AttendanceViewModel
 import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
 
@@ -72,7 +73,14 @@ fun AppNavGraph(
 
             AttendanceScreen(
                 state = state,
-                teiCardMapper = teiCardMapper
+                teiCardMapper = teiCardMapper,
+                onEvent = {
+                    when (it) {
+                        is AttendanceUiEvent.NavBack -> navController.navigateUp()
+                        is AttendanceUiEvent.OnSyncClicked -> syncData()
+                        else -> attendanceViewModel.handleUiEvent(it)
+                    }
+                }
             )
         }
     }

--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeScreen.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.saudigitus.semis.app.presentation.navigation.AppRoutes
 import org.saudigitus.semis.core.designsystem.R
-import org.saudigitus.semis.core.designsystem.components.ConfigNotFoud
+import org.saudigitus.semis.core.designsystem.components.ConfigNotFound
 import org.saudigitus.semis.core.designsystem.components.FilterDetails
 import org.saudigitus.semis.core.designsystem.components.NoRecordsFound
 import org.saudigitus.semis.core.designsystem.components.cards.ActionCard
@@ -92,7 +92,7 @@ fun HomeScreen(
                 }
             }
         } else {
-            ConfigNotFoud(Modifier.fillMaxWidth().padding(horizontal = 16.dp))
+            ConfigNotFound(Modifier.fillMaxWidth().padding(horizontal = 16.dp))
         }
     }
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/AttendanceTransformation.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/AttendanceTransformation.kt
@@ -1,0 +1,99 @@
+package org.saudigitus.semis.attendance.data
+
+import androidx.compose.ui.graphics.Color
+import org.dhis2.commons.bindings.enrollment
+import org.dhis2.commons.date.DateUtils
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.event.Event
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEvent
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+import org.saudigitus.semis.core.data.model.app_config.Attendance
+import org.saudigitus.semis.core.data.utils.Transformations
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonDecorator
+import org.saudigitus.semis.core.designsystem.utils.UiDefaults
+import org.saudigitus.semis.core.designsystem.utils.UiDefaults.getAttendanceStatusColor
+import org.saudigitus.semis.core.utils.DateHelper
+import javax.inject.Inject
+
+class AttendanceTransformation @Inject constructor(
+    private val d2: D2,
+    private val transformation: Transformations
+) {
+
+    fun teiEventTransform(
+        eventUid: String,
+        program: String,
+        attendanceDataElement: String,
+        reasonDataElement: String,
+        config: Attendance?,
+    ): AttendanceEventWithDecorator {
+        val event = d2.eventModule().events()
+            .byUid().eq(eventUid)
+            .withTrackedEntityDataValues()
+            .one().blockingGet()
+
+        val enrollment = d2.enrollment(event!!.enrollment().orEmpty())
+
+        val tei = d2.trackedEntityModule()
+            .trackedEntityInstances()
+            .byUid().eq(enrollment?.trackedEntityInstance())
+            .withTrackedEntityAttributeValues()
+            .one().blockingGet()
+
+        val teiModel = transformation.transform(tei, program, enrollment)
+        val transformedEvent = eventTransform(event, attendanceDataElement, reasonDataElement)
+
+        val status = config?.statusOptions?.find { status ->
+            status?.code == transformedEvent?.value
+        }
+
+        val data = AttendanceEventWithDecorator(
+            tei = teiModel,
+            event = transformedEvent!!,
+            decorator = AttendanceButtonDecorator(
+                containerColor = getAttendanceStatusColor(
+                    status?.key.orEmpty(),
+                    status?.color.orEmpty()
+                ),
+                contentColor = 0xFFFFFFFF
+            ),
+            icon = UiDefaults.dynamicIcons(status?.icon.orEmpty()),
+            iconName = status?.icon.orEmpty(),
+            iconColor = Color.White,
+        )
+
+        return data
+    }
+
+    fun eventTransform(
+        event: Event,
+        dataElement: String,
+        reasonDataElement: String?,
+    ): AttendanceEvent? {
+        val dataValue = event.trackedEntityDataValues()?.find { it.dataElement() == dataElement }
+        val reason = event.trackedEntityDataValues()?.find { it.dataElement() == reasonDataElement }
+
+        return if (dataValue != null) {
+            val tei = d2.enrollment(event.enrollment().toString())?.trackedEntityInstance() ?: ""
+
+            AttendanceEvent(
+                tei = tei,
+                event = event.uid(),
+                enrollment = event.enrollment()!!,
+                dataElement = dataElement,
+                value = dataValue.value().orEmpty(),
+                reasonDataElement = if (reason == null) {
+                    null
+                } else {
+                    reasonDataElement
+                },
+                reasonOfAbsence = reason?.value(),
+                date = DateHelper.formatDate(
+                    event.eventDate()?.time ?: DateUtils.getInstance().today.time,
+                ).orEmpty(),
+            )
+        } else {
+            null
+        }
+    }
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/AttendanceTransformation.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/AttendanceTransformation.kt
@@ -10,6 +10,7 @@ import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWi
 import org.saudigitus.semis.core.data.model.app_config.Attendance
 import org.saudigitus.semis.core.data.utils.Transformations
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonDecorator
+import org.saudigitus.semis.core.designsystem.theme.white
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.getAttendanceStatusColor
 import org.saudigitus.semis.core.utils.DateHelper
@@ -55,7 +56,7 @@ class AttendanceTransformation @Inject constructor(
                     status?.key.orEmpty(),
                     status?.color.orEmpty()
                 ),
-                contentColor = 0xFFFFFFFF
+                contentColor = white
             ),
             icon = UiDefaults.dynamicIcons(status?.icon.orEmpty()),
             iconName = status?.icon.orEmpty(),

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/repository/AttendanceEventRepository.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/repository/AttendanceEventRepository.kt
@@ -1,0 +1,15 @@
+package org.saudigitus.semis.attendance.data.repository
+
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+
+interface AttendanceEventRepository {
+    suspend fun save()
+    suspend fun getAttendanceEvent(
+        teiUids: List<String>,
+        program: String,
+        programStage: String,
+        dataElement: String,
+        reasonDataElement: String,
+        eventDate: String?
+    ): List<AttendanceEventWithDecorator>
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/repository/AttendanceEventRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/data/repository/AttendanceEventRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package org.saudigitus.semis.attendance.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.saudigitus.semis.attendance.data.AttendanceTransformation
+import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.data.repository.EventRepository
+import javax.inject.Inject
+
+class AttendanceEventRepositoryImpl @Inject constructor(
+    private val eventRepository: EventRepository,
+    private val appConfigRepository: AppConfigRepository,
+    private val transformations: AttendanceTransformation,
+) : AttendanceEventRepository {
+    override suspend fun save() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getAttendanceEvent(
+        teiUids: List<String>,
+        program: String,
+        programStage: String,
+        dataElement: String,
+        reasonDataElement: String,
+        eventDate: String?
+    ) = withContext(Dispatchers.IO) {
+        val config = appConfigRepository.getAppConfig(program)
+
+        eventRepository.getEvents(
+            teiUids = teiUids,
+            program = program,
+            programStage = programStage,
+            eventDate = eventDate,
+        ).map {
+            transformations.teiEventTransform(
+                eventUid = it.uid(),
+                program = program,
+                attendanceDataElement = dataElement,
+                reasonDataElement = reasonDataElement,
+                config = config?.attendance,
+            )
+        }
+    }
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
@@ -4,9 +4,13 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import org.saudigitus.semis.attendance.data.AttendanceTransformation
+import org.saudigitus.semis.attendance.data.repository.AttendanceEventRepository
+import org.saudigitus.semis.attendance.data.repository.AttendanceEventRepositoryImpl
 import org.saudigitus.semis.attendance.data.repository.AttendanceOptionRepository
 import org.saudigitus.semis.attendance.data.repository.AttendanceOptionRepositoryImpl
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.data.repository.EventRepository
 import org.saudigitus.semis.core.data.repository.OptionRepository
 import javax.inject.Singleton
 
@@ -23,4 +27,17 @@ object AttendanceModule {
         return AttendanceOptionRepositoryImpl(optionRepository, appConfigRepository)
     }
 
+    @Provides
+    @Singleton
+    fun provideAttendanceEventRepository(
+        eventRepository: EventRepository,
+        appConfigRepository: AppConfigRepository,
+        attendanceTransformation: AttendanceTransformation
+    ): AttendanceEventRepository {
+        return AttendanceEventRepositoryImpl(
+            eventRepository,
+            appConfigRepository,
+            attendanceTransformation
+        )
+    }
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
@@ -31,8 +33,10 @@ import org.hisp.dhis.mobile.ui.designsystem.component.ListCardDescriptionModel
 import org.hisp.dhis.mobile.ui.designsystem.component.ListCardTitleModel
 import org.hisp.dhis.mobile.ui.designsystem.component.state.rememberAdditionalInfoColumnState
 import org.hisp.dhis.mobile.ui.designsystem.component.state.rememberListCardState
+import org.saudigitus.semis.attendance.ui.model.ButtonStep
 import org.saudigitus.semis.core.designsystem.R
 import org.saudigitus.semis.core.designsystem.attendance.AttendanceButton
+import org.saudigitus.semis.core.designsystem.components.ConfigNotFound
 import org.saudigitus.semis.core.designsystem.components.FilterDetails
 import org.saudigitus.semis.core.designsystem.components.NoResults
 import org.saudigitus.semis.core.designsystem.components.ToolbarActionState
@@ -44,6 +48,7 @@ import org.saudigitus.semis.core.designsystem.utils.mapper.searchTeiMapper
 fun AttendanceScreen(
     state: AttendanceUiState,
     teiCardMapper: TEICardMapper,
+    onEvent: (AttendanceUiEvent) -> Unit,
 ) {
     TopAppBarScaffold(
         toolbarHeaders = state.toolbarHeaders,
@@ -51,11 +56,18 @@ fun AttendanceScreen(
             filterVisibility = false,
             showCalendar = true
         ),
+        navigationAction = { onEvent(AttendanceUiEvent.NavBack) },
+        syncAction = { onEvent(AttendanceUiEvent.OnSyncClicked) },
+        calendarAction = { onEvent(AttendanceUiEvent.OnDateSelect(it)) },
         floatingActionButton = {
             ExtendedFloatingActionButton(
                 text = {
                     Text(
-                        text = stringResource(R.string.save),
+                        text = if (state.buttonStep == ButtonStep.NONE) {
+                            stringResource(R.string.update)
+                        } else {
+                            stringResource(R.string.save)
+                        },
                         color = colorPrimary,
                         style = LocalTextStyle.current.copy(
                             fontFamily = FontFamily(Font(R.font.rubik_medium)),
@@ -64,12 +76,22 @@ fun AttendanceScreen(
                 },
                 icon = {
                     Icon(
-                        imageVector = Icons.Default.Edit,
+                        imageVector = if (state.buttonStep == ButtonStep.NONE) {
+                            Icons.Default.Edit
+                        } else {
+                            Icons.Default.Save
+                        },
                         contentDescription = null,
                         tint = colorPrimary,
                     )
                 },
-                onClick = {  },
+                onClick = {
+                    if (state.buttonStep == ButtonStep.NONE) {
+                        onEvent(AttendanceUiEvent.OnEditClicked)
+                    } else {
+                        onEvent(AttendanceUiEvent.OnSaveClicked)
+                    }
+                },
             )
         }
     ) {
@@ -80,7 +102,7 @@ fun AttendanceScreen(
         )
 
         if (state.isLoading) {
-            Box (
+            Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
@@ -89,6 +111,17 @@ fun AttendanceScreen(
         } else if (state.teis.isEmpty()) {
             NoResults(message = stringResource(id = R.string.no_records_found))
         } else {
+            if (state.attendanceButtonState.buttons.isEmpty()) {
+                ConfigNotFound(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentHeight()
+                        .padding(horizontal = 16.dp),
+                    iconSize = 32.dp,
+                    message = stringResource(id = R.string.app_not_properly_config)
+                )
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 16.dp, top = 10.dp, bottom = 108.dp)
@@ -97,7 +130,7 @@ fun AttendanceScreen(
                     val card = searchTeiMapper(
                         tei = tei,
                         teiCardMapper = teiCardMapper,
-                        onImageClick = {  },
+                        onImageClick = { },
                         onCardClick = { tei, enrollment ->
 
                         }
@@ -139,11 +172,18 @@ fun AttendanceScreen(
                             listAvatar = card.first.avatar,
                         )
                         AttendanceButton(
+                            key = tei.uid(),
                             modifier = Modifier.padding(horizontal = 16.dp),
-                            state = state.attendanceButtonState
-                        ) {
-
-                        }
+                            state = state.attendanceButtonState,
+                            onClick = {
+                                onEvent(
+                                    AttendanceUiEvent.OnAttendanceClick(
+                                        tei = tei.uid(),
+                                        buttonModel = it
+                                    )
+                                )
+                            }
+                        )
                     }
                 }
             }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
@@ -1,0 +1,13 @@
+package org.saudigitus.semis.attendance.ui
+
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+
+sealed class AttendanceUiEvent {
+    data object NavBack : AttendanceUiEvent()
+    data class OnDateSelect(val date: String) : AttendanceUiEvent()
+    data object OnSyncClicked : AttendanceUiEvent()
+    data object OnEditClicked : AttendanceUiEvent()
+    data object OnSaveClicked : AttendanceUiEvent()
+    data class OnAttendanceClick(val tei: String, val buttonModel: AttendanceButtonModel) :
+        AttendanceUiEvent()
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
@@ -1,5 +1,6 @@
 package org.saudigitus.semis.attendance.ui
 
+import org.saudigitus.semis.attendance.ui.model.ButtonStep
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
@@ -9,6 +10,7 @@ data class AttendanceUiState(
     val isLoading: Boolean = false,
     val toolbarHeaders: ToolbarHeaders = ToolbarHeaders(""),
     val program: String = "",
+    val buttonStep: ButtonStep = ButtonStep.NONE,
     val teis: List<SearchTeiModel> = emptyList(),
     val filterDetailsState: FilterDetailsState = FilterDetailsState(),
     val attendanceButtonState: AttendanceButtonState = AttendanceButtonState(),

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -10,8 +10,14 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.dhis2.commons.resources.ResourceManager
 import org.saudigitus.semis.attendance.R
+import org.saudigitus.semis.attendance.data.repository.AttendanceEventRepository
 import org.saudigitus.semis.attendance.data.repository.AttendanceOptionRepository
+import org.saudigitus.semis.attendance.ui.model.ButtonStep
 import org.saudigitus.semis.core.data.model.SearchTeiModel
+import org.saudigitus.semis.core.data.model.app_config.Attendance
+import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
 import org.saudigitus.semis.core.designsystem.components.model.ToolbarHeaders
 import org.saudigitus.semis.core.utils.DateHelper
@@ -20,8 +26,13 @@ import javax.inject.Inject
 @HiltViewModel
 class AttendanceViewModel @Inject constructor(
     private val attendanceOptionRepository: AttendanceOptionRepository,
+    private val attendanceEventRepository: AttendanceEventRepository,
+    private val appConfigRepository: AppConfigRepository,
     private val resourceManager: ResourceManager
 ) : ViewModel() {
+
+    private var attendanceConfig: Attendance? = null
+    private var studentsIds: List<String> = emptyList()
 
     private val _uiState = MutableStateFlow(
         AttendanceUiState(
@@ -39,26 +50,103 @@ class AttendanceViewModel @Inject constructor(
             _uiState.value
         )
 
+
+    private suspend fun buttonState(
+        program: String,
+        attendanceEvents: List<AttendanceEventWithDecorator>
+    ): AttendanceButtonState {
+        val current = uiState.value.attendanceButtonState
+        val options = attendanceOptionRepository.getAttendanceStatusOptions(program)
+
+        return current.copy(
+            isLoading = false,
+            buttons = options,
+            attendanceEvents = attendanceEvents
+        )
+    }
+
     fun initialize(
         program: String,
         teis: List<SearchTeiModel>,
         filterDetailsState: FilterDetailsState
     ) {
         viewModelScope.launch {
-            val options = attendanceOptionRepository.getAttendanceStatusOptions(program)
-            val current = uiState.value.attendanceButtonState
+            studentsIds = teis.mapNotNull { it.tei.uid() }
 
-            val buttonState = current.copy(key = "${('A'..'Z').random()}", buttons = options)
+            val config = appConfigRepository.getAppConfig(program)
+            attendanceConfig = config?.attendance
 
             _uiState.update {
                 it.copy(
                     isLoading = false,
                     program = program,
                     teis = teis,
-                    attendanceButtonState = buttonState,
                     filterDetailsState = filterDetailsState
                 )
             }
+
+            loadAttendanceEventsByDate()
+        }
+    }
+
+    private fun loadAttendanceEventsByDate(date: String? = null) {
+        viewModelScope.launch {
+            val currentToolbar = uiState.value.toolbarHeaders
+            var updatedToolbar = currentToolbar
+
+            if (date != null) {
+                updatedToolbar = currentToolbar.copy(
+                    subtitle = DateHelper.formatDateWithWeekDay(date)
+                )
+            }
+
+            val attendanceEvents = attendanceEventRepository.getAttendanceEvent(
+                teiUids = studentsIds,
+                program = uiState.value.program,
+                programStage = attendanceConfig?.programStage.orEmpty(),
+                dataElement = attendanceConfig?.status.orEmpty(),
+                reasonDataElement = attendanceConfig?.absenceReason.orEmpty(),
+                eventDate = date ?: DateHelper.formatDate(System.currentTimeMillis())
+                    .orEmpty()
+            )
+
+            val currentButtonState = buttonState(uiState.value.program, attendanceEvents)
+
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    toolbarHeaders = updatedToolbar,
+                    attendanceButtonState = currentButtonState,
+                )
+            }
+        }
+    }
+
+    fun handleUiEvent(uiEvent: AttendanceUiEvent) {
+        when (uiEvent) {
+            is AttendanceUiEvent.OnDateSelect -> {
+                loadAttendanceEventsByDate(uiEvent.date)
+            }
+
+            is AttendanceUiEvent.OnEditClicked -> {
+                val current = uiState.value.attendanceButtonState
+
+                _uiState.update {
+                    it.copy(
+                        buttonStep = ButtonStep.EDITING,
+                        attendanceButtonState = current.copy(
+                            isEditing = true,
+                        )
+                    )
+                }
+            }
+
+            is AttendanceUiEvent.OnAttendanceClick -> {
+
+            }
+
+            is AttendanceUiEvent.OnSaveClicked -> {}
+            else -> {}
         }
     }
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/ButtonStep.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/ButtonStep.kt
@@ -1,0 +1,7 @@
+package org.saudigitus.semis.attendance.ui.model
+
+enum class ButtonStep {
+    NONE,
+    EDITING,
+    SAVING,
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/utils/AttendanceExtensions.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/utils/AttendanceExtensions.kt
@@ -1,0 +1,54 @@
+package org.saudigitus.semis.attendance.utils
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonDecorator
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+import java.security.acl.Owner
+
+fun AttendanceEventWithDecorator.withIconProps(
+    icon: ImageVector,
+    iconName: String,
+    iconColor: Color,
+) = copy(
+    icon = icon,
+    iconName = iconName,
+    iconColor = iconColor
+)
+
+fun AttendanceEventWithDecorator.withDecoratorAndIconProps(
+    decorator: AttendanceButtonDecorator,
+    icon: ImageVector,
+    iconName: String,
+    iconColor: Color,
+) = copy(
+    decorator = decorator,
+    icon = icon,
+    iconName = iconName,
+    iconColor = iconColor
+)
+
+fun AttendanceEventWithDecorator.withDecorator(
+    decorator: AttendanceButtonDecorator,
+) = copy(
+    decorator = decorator,
+)
+
+fun AttendanceButtonModel.withProps(
+    owner: String? = null,
+    icon: ImageVector?,
+    iconName: String?,
+    iconColor: Color?,
+) = AttendanceButtonModel(
+    key = this.key,
+    owner = owner,
+    code = this.code,
+    name = this.name,
+    dataElement = this.dataElement,
+    order = this.order,
+    enabled = this.enabled,
+    icon = icon,
+    iconName = iconName,
+    color = iconColor
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/di/DataModule.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/di/DataModule.kt
@@ -13,6 +13,8 @@ import org.saudigitus.semis.core.data.repository.AppConfigRepository
 import org.saudigitus.semis.core.data.repository.AppConfigRepositoryImpl
 import org.saudigitus.semis.core.data.repository.AppModulesRepository
 import org.saudigitus.semis.core.data.repository.AppModulesRepositoryImpl
+import org.saudigitus.semis.core.data.repository.EventRepository
+import org.saudigitus.semis.core.data.repository.EventRepositoryImpl
 import org.saudigitus.semis.core.data.repository.FilterRepository
 import org.saudigitus.semis.core.data.repository.FilterRepositoryImpl
 import org.saudigitus.semis.core.data.repository.OptionRepository
@@ -75,4 +77,10 @@ object DataModule {
         d2: D2,
         transformations: Transformations
     ): TeiRepository = TeiRepositoryImpl(d2, transformations)
+
+    @Provides
+    @Singleton
+    fun provideEventRepository(
+        d2: D2,
+    ): EventRepository = EventRepositoryImpl(d2)
 }

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
@@ -1,0 +1,18 @@
+package org.saudigitus.semis.core.data.repository
+
+import org.hisp.dhis.android.core.event.Event
+
+interface EventRepository {
+    suspend fun saveEvent(
+        orgUnit: String,
+        program: String,
+        enrollment: String,
+        programStage: String
+    )
+    suspend fun getEvents(
+        teiUids: List<String>,
+        program: String,
+        programStage: String,
+        eventDate: String?
+    ): List<Event>
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package org.saudigitus.semis.core.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.dhis2.commons.date.DateUtils
+import org.hisp.dhis.android.core.D2
+import java.sql.Date
+import javax.inject.Inject
+
+class EventRepositoryImpl @Inject constructor(
+    val d2: D2
+): EventRepository {
+    override suspend fun saveEvent(
+        orgUnit: String,
+        program: String,
+        enrollment: String,
+        programStage: String
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getEvents(
+        teiUids: List<String>,
+        program: String,
+        programStage: String,
+        eventDate: String?
+    ) = withContext(Dispatchers.IO) {
+        val date = if (eventDate != null) {
+            Date.valueOf(eventDate)
+        } else {
+            DateUtils.getInstance().today
+        }
+
+        d2.eventModule().events()
+            .byTrackedEntityInstanceUids(teiUids)
+            .byProgramUid().eq(program)
+            .byProgramStageUid().eq(programStage)
+            .byDeleted().isFalse
+            .byEventDate().eq(date)
+            .withTrackedEntityDataValues()
+            .blockingGet()
+    }
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Transformations.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Transformations.kt
@@ -106,7 +106,7 @@ class Transformations @Inject constructor(private val d2: D2) {
                 .organisationUnits()
                 .uid(orgUnitUid)
                 .blockingGet()
-            orgUnitNameCache.put(orgUnitUid, organisationUnit!!.displayName())
+            orgUnitNameCache[orgUnitUid] = organisationUnit!!.displayName()
         }
         return orgUnitNameCache[orgUnitUid]
     }

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButton.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButton.kt
@@ -1,9 +1,13 @@
 package org.saudigitus.semis.core.designsystem.attendance
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -14,40 +18,112 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import org.hisp.dhis.mobile.ui.designsystem.component.ProgressIndicator
+import org.hisp.dhis.mobile.ui.designsystem.component.ProgressIndicatorType
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+import org.saudigitus.semis.core.designsystem.utils.UiDefaults
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.GRAY
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.getIconByName
 
 @Composable
 fun AttendanceButton(
+    key: String,
     modifier: Modifier = Modifier,
     state: AttendanceButtonState,
     onClick: (AttendanceButtonModel) -> Unit
 ) {
-    LazyRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        itemsIndexed(
-            state.buttons.toList(),
-            key = { index, item -> item.key }
-        ) { index, item ->
+
+    if (state.isLoading) {
+        ProgressIndicator(
+            modifier = modifier.then(Modifier.size(28.dp)),
+            type = ProgressIndicatorType.CIRCULAR_SMALL
+        )
+    } else if (state.buttons.isEmpty()) {
+        Icon(
+            modifier = modifier.then(Modifier.size(45.dp)),
+            imageVector = Icons.AutoMirrored.Filled.Help,
+            contentDescription = null,
+            tint = Color.LightGray
+        )
+    } else if (state.isEditing) {
+        LazyRow(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            itemsIndexed(state.buttons) { _, item ->
+                val event = state.attendanceEvents.find { it.event?.tei == key }
+
+                IconButton(
+                    onClick = {
+                        onClick.invoke(item)
+                    },
+                    enabled = item.enabled,
+                    modifier = Modifier
+                        .border(
+                            width = (0.15).dp,
+                            color = Color.LightGray,
+                            shape = RoundedCornerShape(100.dp)
+                        )
+                        .size(45.dp),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = if (event != null && event.event?.value == item.code) {
+                            event.decorator?.containerColor ?: Color.White
+                        } else Color.White,
+                        contentColor = if (event != null && event.event?.value == item.code) {
+                            Color(event.decorator?.contentColor ?: GRAY)
+                        } else {
+                            item.color
+                                ?: UiDefaults.getAttendanceStatusColor(item.code.orEmpty())
+                        },
+                    )
+                ) {
+                    Icon(
+                        imageVector = item.icon
+                            ?: ImageVector.vectorResource(getIconByName(item.iconName.orEmpty())),
+                        contentDescription = item.name,
+                    )
+                }
+            }
+        }
+    } else if (state.attendanceEvents.isEmpty()) {
+        Icon(
+            modifier = modifier.then(Modifier.size(45.dp)),
+            imageVector = Icons.AutoMirrored.Filled.Help,
+            contentDescription = null,
+            tint = Color.LightGray
+        )
+    } else {
+        val event = state.attendanceEvents.find { it.event?.tei == key }
+
+        if (event == null) {
+            Icon(
+                modifier = modifier.then(Modifier.size(45.dp)),
+                imageVector = Icons.AutoMirrored.Filled.Help,
+                contentDescription = null,
+                tint = Color.LightGray
+            )
+        } else {
             IconButton(
-                onClick = {
-                    onClick.invoke(item)
-                },
-                enabled = item.enabled,
-                modifier = Modifier.size(40.dp),
+                onClick = {},
+                modifier = modifier.then(
+                    Modifier
+                        .border(
+                            width = (0.15).dp,
+                            color = Color.LightGray,
+                            shape = RoundedCornerShape(100.dp)
+                        )
+                        .size(45.dp)
+                ),
                 colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = state.buttonDecorators.getOrNull(index)?.containerColor ?: Color.LightGray,
-                    contentColor = Color(state.buttonDecorators.getOrNull(index)?.contentColor ?: GRAY),
+                    containerColor = event.decorator?.containerColor ?: Color.White,
+                    contentColor = Color(event.decorator?.contentColor ?: GRAY),
                 )
             ) {
                 Icon(
-                    imageVector = item.icon
-                        ?: ImageVector.vectorResource(getIconByName(item.iconName.orEmpty())),
-                    contentDescription = item.name,
+                    imageVector = event.icon
+                        ?: ImageVector.vectorResource(getIconByName(event.iconName.orEmpty())),
+                    contentDescription = event.iconName,
                 )
             }
         }

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButtonState.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButtonState.kt
@@ -3,10 +3,15 @@ package org.saudigitus.semis.core.designsystem.attendance
 import androidx.compose.runtime.Immutable
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonDecorator
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonWithDecorator
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+import org.saudigitus.semis.core.utils.Utils
 
 @Immutable
 data class AttendanceButtonState(
-    val key: String = "",
+    val key: String = Utils.generateRandomId(),
+    val isLoading: Boolean = true,
+    val isEditing: Boolean = false,
     val buttons: List<AttendanceButtonModel> = emptyList(),
-    val buttonDecorators: List<AttendanceButtonDecorator> = emptyList()
+    val attendanceEvents: List<AttendanceEventWithDecorator> = emptyList(),
 )

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonDecorator.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonDecorator.kt
@@ -7,4 +7,8 @@ data class AttendanceButtonDecorator(
     val buttonType: String? = null,
     val containerColor: Color? = null,
     val contentColor: Long = 0xFF888888,
-)
+) {
+    override fun toString(): String {
+        return "AttendanceButtonDecorator(buttonType=$buttonType, containerColor=$containerColor, contentColor=$contentColor)"
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonModel.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 data class AttendanceButtonModel(
     val key: String = "",
+    val owner: String? = null,
     val code: String? = null,
     val name: String? = null,
     val dataElement: String? = null,
@@ -13,4 +14,8 @@ data class AttendanceButtonModel(
     val enabled: Boolean = true,
     val color: Color? = null,
     val order: Int? = null,
-)
+) {
+    override fun toString(): String {
+        return "AttendanceButtonModel(key='$key')"
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonWithDecorator.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonWithDecorator.kt
@@ -1,0 +1,10 @@
+package org.saudigitus.semis.core.designsystem.attendance.model
+
+data class AttendanceButtonWithDecorator(
+    val button: AttendanceButtonModel? = null,
+    val decorator: AttendanceButtonDecorator? = null
+) {
+    override fun toString(): String {
+        return "AttendanceButtonWithDecorator(button=$button, decorator=$decorator)"
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceEvent.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceEvent.kt
@@ -1,0 +1,12 @@
+package org.saudigitus.semis.core.designsystem.attendance.model
+
+data class AttendanceEvent(
+    val tei: String,
+    val enrollment: String,
+    val event: String? = null,
+    val dataElement: String,
+    val reasonDataElement: String? = null,
+    val reasonOfAbsence: String? = null,
+    val value: String,
+    val date: String,
+)

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceEventWithDecorator.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceEventWithDecorator.kt
@@ -1,0 +1,18 @@
+package org.saudigitus.semis.core.designsystem.attendance.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.saudigitus.semis.core.data.model.SearchTeiModel
+
+data class AttendanceEventWithDecorator(
+    val tei: SearchTeiModel? = null,
+    val event: AttendanceEvent? = null,
+    val decorator: AttendanceButtonDecorator? = null,
+    val icon:  ImageVector? = null,
+    val iconName: String? = null,
+    val iconColor: Color? = null,
+) {
+    override fun toString(): String {
+        return "AttendanceEventWithDecorator(tei=$tei, event=$event, decorator=$decorator, icon=$icon, iconName=$iconName, iconColor=$iconColor)"
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/NotFound.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/NotFound.kt
@@ -28,14 +28,18 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.saudigitus.semis.core.designsystem.R
 import org.saudigitus.semis.core.designsystem.theme.dark_warning
 
 @Composable
-fun ConfigNotFoud(
-    modifier: Modifier = Modifier
+fun ConfigNotFound(
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 74.dp,
+    imageVector: ImageVector = ImageVector.vectorResource(R.drawable.settings_alert),
+    message: String = stringResource(R.string.config_not_found)
 ) {
     Card(
         modifier = modifier,
@@ -51,13 +55,13 @@ fun ConfigNotFoud(
             verticalArrangement = Arrangement.Center,
         ) {
             Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.settings_alert),
-                contentDescription = stringResource(R.string.config_not_found),
-                modifier = Modifier.size(74.dp),
+                imageVector = imageVector,
+                contentDescription = message,
+                modifier = Modifier.size(iconSize),
                 tint = dark_warning
             )
             Text(
-                text = stringResource(R.string.config_not_found),
+                text = message,
                 color = dark_warning,
                 textAlign = TextAlign.Center
             )

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/templates/TopAppBarScaffold.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/templates/TopAppBarScaffold.kt
@@ -31,6 +31,7 @@ fun TopAppBarScaffold(
         showFavorite = true,
     ),
     navigationAction: () -> Unit = {},
+    calendarAction: (String) -> Unit = {},
     filterAction: () -> Unit = {},
     syncAction: () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit,
@@ -48,6 +49,7 @@ fun TopAppBarScaffold(
                 navigationAction = navigationAction,
                 disableNavigation = false,
                 actionState = toolbarActionState,
+                calendarAction = calendarAction,
                 filterAction = filterAction,
                 syncAction = syncAction,
             )

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/Color.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/Color.kt
@@ -73,3 +73,5 @@ val light_error = Color(0xFFE57373)
 
 
 val dark_warning = Color(0xFFFD9600)
+
+val white = 0xFFFFFFFF

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/ModifierExtensions.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/ModifierExtensions.kt
@@ -1,0 +1,53 @@
+package org.saudigitus.semis.core.designsystem.utils
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+fun Modifier.shimmer(): Modifier = composed {
+    var size by remember { mutableStateOf(IntSize.Zero) }
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val startOffsetX by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 2000f,  // Adjust for wave speed/length
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000, easing = LinearEasing),  // Duration in ms
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmer_offset"
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                Color(0xFFf0f0f0),  // Base color
+                Color(0xFFe0e0e0),  // Highlight start
+                Color(0xFFf0f0f0),  // Peak
+                Color(0xFFe0e0e0),  // Fade
+                Color(0xFFf0f0f0)   // End
+            ),
+            start = Offset(startOffsetX - size.width, 0f),
+            end = Offset(startOffsetX + size.width, size.height.toFloat())
+        ),
+        shape = RoundedCornerShape(16.dp)
+    ).onGloballyPositioned { coordinates ->
+        size = coordinates.size
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/UiDefaults.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/UiDefaults.kt
@@ -43,7 +43,7 @@ object UiDefaults {
         }
     }
 
-    private fun getAttendanceStatusColor(key: String): Color {
+    fun getAttendanceStatusColor(key: String): Color {
         return when (key) {
             "present" -> Color(0xFF81C784)
             "absent" -> Color(0xFFE57373)

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="enrolledIn">Enrolled in</string>
     <string name="marked_follow_up">Marked for follow-up</string>
     <string name="sync_error_title">Sync Error</string>
+    <string name="update">Update</string>
+    <string name="app_not_properly_config">App not configured properly. Please contact System Administrator</string>
 </resources>

--- a/semis/core/utils/src/main/java/org/saudigitus/semis/core/utils/Utils.kt
+++ b/semis/core/utils/src/main/java/org/saudigitus/semis/core/utils/Utils.kt
@@ -1,0 +1,13 @@
+package org.saudigitus.semis.core.utils
+
+import kotlin.random.Random
+
+object Utils {
+
+    fun generateRandomId(length: Int = 11): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        return (1..length)
+            .map { chars[Random.nextInt(chars.length)] }
+            .joinToString("")
+    }
+}


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-59).

Fetch and display attendance events linked to each TEI. Reflect attendance status visually (e.g., icons, colors, or labels). Support live updates when status changes. Ensure consistency with backend data on refresh or sync.