### PR TITLE
feat: [SEMIS-82] adds confirmation dialog on save and when overriding attendance through bulk attendance

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
@@ -63,12 +63,13 @@ fun AppNavGraph(
         composable(route = AppRoutes.ATTENDANCE) {
             val attendanceViewModel = hiltViewModel<AttendanceViewModel>()
             val formViewModel = hiltViewModel<FormViewModel>()
-            val state by attendanceViewModel.uiState.collectAsStateWithLifecycle()
+
             val homeState by viewModel.uiState.collectAsStateWithLifecycle()
 
             LaunchedEffect(key1 = Unit) {
                 attendanceViewModel.initialize(
                     homeState.program,
+                    homeState.filterState.orgUnit?.uid.orEmpty(),
                     homeState.tei,
                     homeState.filterState.filterDetailsState
                 )
@@ -78,7 +79,6 @@ fun AppNavGraph(
                 activity = activity,
                 viewModel = attendanceViewModel,
                 formViewModel = formViewModel,
-                state = state,
                 teiCardMapper = teiCardMapper,
                 navController = navController,
                 syncData = syncData

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -124,7 +124,7 @@ fun AttendanceScreen(
         AlertDialog(
             message = stringResource(id = R.string.override_attendance),
             onConfirm = {
-                onEvent(AttendanceUiEvent.BottomSheetAction(BottomSheetConfirmAction.PERFORM_SAVE))
+                onEvent(AttendanceUiEvent.BulkOverrideAttendance)
             }
         )
     }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -45,19 +45,20 @@ import org.hisp.dhis.mobile.ui.designsystem.component.state.rememberListCardStat
 import org.hisp.dhis.mobile.ui.designsystem.theme.Radius
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.dropShadow
-import org.saudigitus.semis.core.designsystem.components.summary.SummaryDetails
 import org.saudigitus.semis.attendance.ui.components.BulkCard
 import org.saudigitus.semis.attendance.ui.model.BottomSheetConfirmAction
 import org.saudigitus.semis.attendance.ui.model.BottomSheetType
 import org.saudigitus.semis.attendance.ui.model.ButtonStep
 import org.saudigitus.semis.core.designsystem.R
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+import org.saudigitus.semis.core.designsystem.components.AlertDialog
 import org.saudigitus.semis.core.designsystem.components.ConfigNotFound
 import org.saudigitus.semis.core.designsystem.components.NoResults
 import org.saudigitus.semis.core.designsystem.components.SnackBar
 import org.saudigitus.semis.core.designsystem.components.ToolbarActionState
 import org.saudigitus.semis.core.designsystem.components.bottomsheet.ListingBottomSheet
 import org.saudigitus.semis.core.designsystem.components.bottomsheet.model.BottomSheetState
+import org.saudigitus.semis.core.designsystem.components.summary.SummaryDetails
 import org.saudigitus.semis.core.designsystem.templates.TopAppBarScaffold
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults
 import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
@@ -107,6 +108,24 @@ fun AttendanceScreen(
                     }
                 }
             },
+        )
+    }
+
+    if (state.displayDialog) {
+        AlertDialog(
+            message = stringResource(id = R.string.save_alert),
+            onConfirm = {
+                onEvent(AttendanceUiEvent.BottomSheetAction(BottomSheetConfirmAction.PERFORM_SAVE))
+            }
+        )
+    }
+
+    if (state.overrideBulk) {
+        AlertDialog(
+            message = stringResource(id = R.string.override_attendance),
+            onConfirm = {
+                onEvent(AttendanceUiEvent.BottomSheetAction(BottomSheetConfirmAction.PERFORM_SAVE))
+            }
         )
     }
 
@@ -165,7 +184,8 @@ fun AttendanceScreen(
         }
     ) {
         SummaryDetails(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
                 .padding(5.dp)
                 .dropShadow(RoundedCornerShape(Radius.S))
                 .background(
@@ -199,7 +219,12 @@ fun AttendanceScreen(
 
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 108.dp),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = 10.dp,
+                    end = 16.dp,
+                    bottom = 108.dp
+                ),
                 verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
@@ -221,7 +246,10 @@ fun AttendanceScreen(
                                 color = SurfaceColor.SurfaceBright,
                                 shape = RoundedCornerShape(Radius.S)
                             ),
-                        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+                        verticalArrangement = Arrangement.spacedBy(
+                            12.dp,
+                            Alignment.CenterVertically
+                        ),
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         ListCard(
@@ -258,6 +286,7 @@ fun AttendanceScreen(
                         )
                         FormContent(
                             key = tei.uid(),
+                            tei = tei,
                             type = FormType.ATTENDANCE,
                             modifier = Modifier.fillMaxWidth(),
                             state = formState,

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
@@ -1,5 +1,6 @@
 package org.saudigitus.semis.attendance.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -20,13 +21,13 @@ fun AttendanceUi(
     activity: FragmentActivity,
     viewModel: AttendanceViewModel,
     formViewModel: FormViewModel,
-    state: AttendanceUiState,
     teiCardMapper: TEICardMapper,
     navController: NavHostController,
     syncData: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
     val formState by formViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
@@ -42,6 +43,33 @@ fun AttendanceUi(
 
     LaunchedEffect(state.formBuilderState) {
         formViewModel.initialize(state.formBuilderState)
+        viewModel.hasCachedValues(
+            formState.hasCachedData
+                || formState.attendanceButtonState.attendanceEvents.isNotEmpty()
+        )
+    }
+
+    fun navigationBack() {
+        if (formState.hasCachedData) {
+            launchBottomSheet(
+                activity.getString(R.string.not_saved),
+                activity.getString(R.string.attendance_not_saved),
+                supportFragmentManager = activity.supportFragmentManager,
+                onDiscard = {
+                    viewModel.resetForm()
+                    navController.navigateUp()
+                },
+                onKeepEdition = { },
+            )
+        } else {
+            viewModel.disableEditing().also {
+                navController.navigateUp()
+            }
+        }
+    }
+
+    BackHandler {
+        navigationBack()
     }
 
     AttendanceScreen(
@@ -53,21 +81,9 @@ fun AttendanceUi(
         onEvent = {
             when (it) {
                 is AttendanceUiEvent.NavBack -> {
-                    if (formState.hasCachedData) {
-                        launchBottomSheet(
-                            activity.getString(R.string.not_saved),
-                            activity.getString(R.string.attendance_not_saved),
-                            supportFragmentManager = activity.supportFragmentManager,
-                            onDiscard = {
-                                viewModel.resetForm()
-                                navController.navigateUp()
-                            },
-                            onKeepEdition = {  },
-                        )
-                    } else {
-                        navController.navigateUp()
-                    }
+                    navigationBack()
                 }
+
                 is AttendanceUiEvent.OnSyncClicked -> syncData()
                 else -> viewModel.handleUiEvent(it)
             }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
@@ -10,6 +10,7 @@ sealed class AttendanceUiEvent {
     data class OnDateSelect(val date: String) : AttendanceUiEvent()
     data object OnSyncClicked : AttendanceUiEvent()
     data object OnEditClicked : AttendanceUiEvent()
+    data object BulkOverrideAttendance : AttendanceUiEvent()
     data class BottomSheetAction(val action: BottomSheetConfirmAction) : AttendanceUiEvent()
     data class DismissBottomSheet(val type: BottomSheetType): AttendanceUiEvent()
     data class ShowBottomSheet(val type: BottomSheetType): AttendanceUiEvent()

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
@@ -13,6 +13,8 @@ import org.saudigitus.semis.core.form.ui.state.FormBuilderState
 data class AttendanceUiState(
     val isLoading: Boolean = false,
     val displayBulk: Boolean = false,
+    val displayDialog: Boolean = false,
+    val overrideBulk: Boolean = false,
     val toolbarHeaders: ToolbarHeaders = ToolbarHeaders(""),
     val dateValidator: (Long) -> Boolean = { _ -> true },
     val program: String = "",

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -38,6 +39,11 @@ class AttendanceViewModel @Inject constructor(
     private var studentsIds: List<String> = emptyList()
     private var selectedDate: String = DateHelper.formatDate(System.currentTimeMillis())
         .orEmpty()
+
+    private var cachedButtonModel: AttendanceButtonModel? = null
+
+    private val _hasCachedData = MutableStateFlow(false)
+    private val hasCachedData: StateFlow<Boolean> = _hasCachedData
 
     private val _snackbarEvent = MutableSharedFlow<String?>()
     val snackbarEvent: SharedFlow<String?> = _snackbarEvent
@@ -74,6 +80,7 @@ class AttendanceViewModel @Inject constructor(
 
     fun initialize(
         program: String,
+        orgUnit: String,
         teis: List<SearchTeiModel>,
         filterDetailsState: FilterDetailsState
     ) {
@@ -95,7 +102,7 @@ class AttendanceViewModel @Inject constructor(
                         filterDetailsState = filterDetailsState
                     ),
                     formBuilderState = currentFormState.copy(
-                        orgUnit = "Shc3qNhrPAz",
+                        orgUnit = orgUnit,
                         program = program,
                         programStage = config?.attendance?.programStage.orEmpty(),
                     )
@@ -105,6 +112,10 @@ class AttendanceViewModel @Inject constructor(
             loadAttendanceEventsByDate()
             attendanceSummary()
         }
+    }
+
+    fun hasCachedValues(cached: Boolean) {
+        _hasCachedData.value = cached
     }
 
     private fun loadAttendanceEventsByDate(date: String? = null) {
@@ -188,6 +199,8 @@ class AttendanceViewModel @Inject constructor(
             is AttendanceUiEvent.OnEditClicked -> {
                 val currentAttendanceSummaryState = uiState.value.attendanceSummaryState
 
+                formRepository.allowFormEdition(true)
+
                 _uiState.update {
                     it.copy(
                         buttonStep = ButtonStep.EDITING,
@@ -196,7 +209,6 @@ class AttendanceViewModel @Inject constructor(
                         ),
                     )
                 }
-                formRepository.allowFormEdition(true)
             }
 
             is AttendanceUiEvent.ShowBottomSheet -> {
@@ -205,7 +217,9 @@ class AttendanceViewModel @Inject constructor(
                         it.copy(displayBulk = true)
                     }
                 } else {
-                    attendanceSummary()
+                    _uiState.update {
+                        it.copy(displayDialog = true)
+                    }
                 }
             }
 
@@ -216,9 +230,26 @@ class AttendanceViewModel @Inject constructor(
             }
 
             is AttendanceUiEvent.PerformBulk -> {
-                bulkAttendance(uiEvent.buttonModel)
-                _uiState.update {
-                    it.copy(displayBulk = false)
+                if (hasCachedData.value) {
+                    cachedButtonModel = uiEvent.buttonModel
+                    _uiState.update {
+                        it.copy(overrideBulk = true)
+                    }
+                } else {
+                    bulkAttendance(uiEvent.buttonModel)
+                    _uiState.update {
+                        it.copy(displayBulk = false)
+                    }
+                }
+            }
+
+            is AttendanceUiEvent.BulkOverrideAttendance -> {
+                if (cachedButtonModel != null) {
+                    bulkAttendance(cachedButtonModel!!)
+                    cachedButtonModel = null
+                    _uiState.update {
+                        it.copy(displayBulk = false, overrideBulk = false)
+                    }
                 }
             }
 
@@ -228,12 +259,18 @@ class AttendanceViewModel @Inject constructor(
                         it.copy(displayBulk = false)
                     }
                 } else {
-                    //TODO: IMPLEMENT ATTENDANCE DATA SAVE
+                    _uiState.update {
+                        it.copy(displayDialog = false)
+                    }
                 }
             }
 
             else -> {}
         }
+    }
+
+    fun disableEditing() {
+        formRepository.allowFormEdition(false)
     }
 
     fun resetForm() {

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/Dialog.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/Dialog.kt
@@ -1,0 +1,76 @@
+package org.saudigitus.semis.core.designsystem.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.dhis2.ui.theme.colorPrimary
+import org.saudigitus.semis.core.designsystem.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlertDialog(
+    modifier: Modifier = Modifier,
+    onDismissRequest: () -> Unit = {  },
+    onConfirm: () -> Unit,
+    message: String
+) {
+    BasicAlertDialog(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        Surface(
+            modifier = Modifier
+                .wrapContentWidth()
+                .wrapContentHeight(),
+            shape = MaterialTheme.shapes.large,
+            tonalElevation = AlertDialogDefaults.TonalElevation,
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    modifier = Modifier.align(Alignment.CenterHorizontally).size(32.dp),
+                    tint = colorPrimary
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = message, textAlign = TextAlign.Center)
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(modifier = Modifier.align(Alignment.End)) {
+                    TextButton(
+                        onClick = onDismissRequest,
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        )
+                    ) {
+                        Text(stringResource(R.string.cancel))
+                    }
+                    TextButton(onClick = onConfirm) {
+                        Text(stringResource(R.string.ok))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="yes_no_mandatory_error">Please select Yes or No</string>
     <string name="required_field">%s is required field</string>
     <string name="form">Form</string>
+    <string name="save_alert">Are you sure? If you continue, your changes will be saved and stored permanently.</string>
+    <string name="override_attendance">If you continue, the existing attendance data will be replaced.</string>
 </resources>

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -32,7 +32,6 @@ import org.saudigitus.semis.core.form.data.repository.AttendanceOptionRepository
 import org.saudigitus.semis.core.form.data.repository.FormRepository
 import org.saudigitus.semis.core.utils.DateHelper
 import javax.inject.Inject
-import kotlin.text.orEmpty
 
 class FormRepositoryImpl @Inject constructor(
     private val d2: D2,
@@ -122,11 +121,15 @@ class FormRepositoryImpl @Inject constructor(
         }
 
         return attendanceButtonState.updateAndGet {
-            it.copy(attendanceEvents =  attendanceEvents)
+            it.copy(attendanceEvents = attendanceEvents)
         }
     }
 
-    override fun updateAttendanceReason(tei: String, dataElement: String, value: String): AttendanceButtonState? {
+    override fun updateAttendanceReason(
+        tei: String,
+        dataElement: String,
+        value: String
+    ): AttendanceButtonState? {
         val attendanceEvents = attendanceButtonStateFlow.value.attendanceEvents.toMutableList()
 
         val event = attendanceEvents.find {
@@ -149,11 +152,9 @@ class FormRepositoryImpl @Inject constructor(
             attendanceEvents.add(eventWithDecorator)
         }
 
-        attendanceButtonState.update {
-            it.copy(attendanceEvents =  attendanceEvents)
+        return attendanceButtonState.updateAndGet {
+            it.copy(attendanceEvents = attendanceEvents)
         }
-
-        return attendanceButtonStateFlow.value
     }
 
     override suspend fun loadAttendanceEvents(

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormViewModel.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -55,7 +56,7 @@ class FormViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             formRepository.attendanceButtonStateFlow
-                .collect { newAttendanceState ->
+                .collectLatest { newAttendanceState ->
                     _uiState.update { currentState ->
                         currentState.copy(attendanceButtonState = newAttendanceState)
                     }


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-82).

**Summary**
A confirmation dialog is needed when users save attendance or override attendance records through bulk actions. This dialog will inform users about the persistence of data and the potential override of existing values.

**Context**
Currently, there is no confirmation dialog when saving attendance or performing bulk attendance actions. This can lead to unintentional data changes.