### PR TITLE
feat: [SEMIS-86] performance module routing

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
@@ -18,6 +18,7 @@ import org.saudigitus.semis.attendance.ui.AttendanceUi
 import org.saudigitus.semis.attendance.ui.AttendanceViewModel
 import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
 import org.saudigitus.semis.core.form.ui.FormViewModel
+import org.saudigitus.semis.performance.route.PerformanceNavGraph
 
 @Composable
 fun AppNavGraph(
@@ -82,6 +83,18 @@ fun AppNavGraph(
                 teiCardMapper = teiCardMapper,
                 navController = navController,
                 syncData = syncData
+            )
+        }
+        composable(route = AppRoutes.PERFORMANCE) {
+            val homeState by viewModel.uiState.collectAsStateWithLifecycle()
+
+            PerformanceNavGraph(
+                homeState.program,
+                homeState.tei,
+                teiCardMapper,
+                homeState.filterState,
+                navController,
+                syncData,
             )
         }
     }

--- a/semis/performance/src/main/java/org/saudigitus/semis/performance/route/Destinations.kt
+++ b/semis/performance/src/main/java/org/saudigitus/semis/performance/route/Destinations.kt
@@ -1,0 +1,7 @@
+package org.saudigitus.semis.performance.route
+
+object Destinations {
+    const val PROGRAM_STAGE = "PROGRAM_STAGE"
+    const val PROGRAM_STAGE_DATA_ELEMENTS = "PROGRAM_STAGE_DATA_ELEMENTS/{programStage}"
+    const val EVENT_CAPTURE = "EVENT_CAPTURE/{programStage}/{dataElement}"
+}

--- a/semis/performance/src/main/java/org/saudigitus/semis/performance/route/PerformanceNavGraph.kt
+++ b/semis/performance/src/main/java/org/saudigitus/semis/performance/route/PerformanceNavGraph.kt
@@ -1,0 +1,54 @@
+package org.saudigitus.semis.performance.route
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import org.saudigitus.semis.core.data.model.SearchTeiModel
+import org.saudigitus.semis.core.designsystem.filters.FilterComponentState
+import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
+import org.saudigitus.semis.performance.route.Destinations.EVENT_CAPTURE
+import org.saudigitus.semis.performance.route.Destinations.PROGRAM_STAGE
+import org.saudigitus.semis.performance.route.Destinations.PROGRAM_STAGE_DATA_ELEMENTS
+
+@Composable
+fun PerformanceNavGraph(
+    program: String,
+    teiList: List<SearchTeiModel> = emptyList(),
+    teiCardMapper: TEICardMapper,
+    filterState: FilterComponentState? = null,
+    parentNavController: NavHostController? = null,
+    syncData: (() -> Unit)? = null,
+) {
+    val navController = rememberNavController()
+
+    NavHost(navController, startDestination = PROGRAM_STAGE) {
+        composable(PROGRAM_STAGE) {
+
+        }
+        composable(
+            route = PROGRAM_STAGE_DATA_ELEMENTS,
+            arguments = listOf(
+                navArgument("programStage") { type = NavType.StringType }
+            )
+        ) { entry ->
+            val programStage = entry.arguments?.getString("programStage").orEmpty()
+
+        }
+        composable(
+            route = EVENT_CAPTURE,
+            arguments = listOf(
+                navArgument("programStage") { type = NavType.StringType },
+                navArgument("dataElement") { type = NavType.StringType },
+            )
+        ) { entry ->
+            val programStage = entry.arguments?.getString("programStage").orEmpty()
+            val dataElement = entry.arguments?.getString("dataElement").orEmpty()
+
+
+        }
+    }
+}


### PR DESCRIPTION
## Description

Link the [JIRA issue](SEMIS-86-create-base-performance-module-routing).

Summary
Implement the base navigation routing for the Performance module. This includes defining and wiring all required destinations. Navigation must support passing and reading parameters between screens using navigation arguments.

Context
The issue involves setting up navigation for the Performance module. It requires the creation of specific destinations and the handling of parameters during navigation.