### PR TITLE
feat: add attendance status management and switch component

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
@@ -1,0 +1,24 @@
+package org.saudigitus.semis.attendance.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.hisp.dhis.android.core.D2
+import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
+import org.saudigitus.semis.attendance.ui.repository.AttendanceRepositoryImpl
+import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.form.data.repository.FormRepository
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AttendanceModule {
+    @Provides
+    @Singleton
+    fun provideAttendanceRepository(
+        d2: D2,
+        appConfigRepository: AppConfigRepository,
+        formRepository: FormRepository
+    ): AttendanceRepository = AttendanceRepositoryImpl(d2, appConfigRepository, formRepository)
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -1,5 +1,6 @@
 package org.saudigitus.semis.attendance.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,7 @@ import org.hisp.dhis.mobile.ui.designsystem.component.state.rememberListCardStat
 import org.hisp.dhis.mobile.ui.designsystem.theme.Radius
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.dropShadow
+import org.saudigitus.semis.attendance.ui.components.AttendanceStatusSwitch
 import org.saudigitus.semis.attendance.ui.components.BulkCard
 import org.saudigitus.semis.attendance.ui.model.BottomSheetConfirmAction
 import org.saudigitus.semis.attendance.ui.model.BottomSheetType
@@ -197,7 +199,18 @@ fun AttendanceScreen(
                     shape = RoundedCornerShape(Radius.S)
                 ),
             state = state.attendanceSummaryState,
-            onBulk = { onEvent(AttendanceUiEvent.ShowBottomSheet(BottomSheetType.BULK)) }
+            onBulk = { onEvent(AttendanceUiEvent.ShowBottomSheet(BottomSheetType.BULK)) },
+            content = {
+                if (state.attendanceStatus != null) {
+                    AttendanceStatusSwitch(
+                        title = state.attendanceStatus.displayName.orEmpty(),
+                        isChecked = state.attendanceStatus.value.toBoolean(),
+                        onCheckedChange = {
+                            onEvent(AttendanceUiEvent.AddAttendanceStatus(it))
+                        }
+                    )
+                }
+            }
         )
 
         if (state.isLoading) {
@@ -309,14 +322,16 @@ fun AttendanceScreen(
                             onCardClick = card.first.onCardCLick,
                             listAvatar = card.first.avatar,
                         )
-                        FormContent(
-                            key = tei.uid(),
-                            tei = tei,
-                            type = FormType.ATTENDANCE,
-                            modifier = Modifier.fillMaxWidth(),
-                            state = formState,
-                            onEvent = onFormEvent
-                        )
+                        AnimatedVisibility(!state.attendanceStatus?.value.toBoolean()) {
+                            FormContent(
+                                key = tei.uid(),
+                                tei = tei,
+                                type = FormType.ATTENDANCE,
+                                modifier = Modifier.fillMaxWidth(),
+                                state = formState,
+                                onEvent = onFormEvent
+                            )
+                        }
                         Spacer(modifier = Modifier.padding(2.dp))
                     }
                 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
@@ -17,4 +17,6 @@ sealed class AttendanceUiEvent {
     data class PerformBulk(val buttonModel: AttendanceButtonModel): AttendanceUiEvent()
     data class OnAttendanceClick(val tei: SearchTeiModel?, val buttonModel: AttendanceButtonModel) :
         AttendanceUiEvent()
+
+    data class AddAttendanceStatus(val status: Boolean): AttendanceUiEvent()
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
@@ -1,6 +1,7 @@
 package org.saudigitus.semis.attendance.ui
 
 import androidx.compose.runtime.Immutable
+import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
 import org.saudigitus.semis.core.designsystem.components.bottomsheet.model.BottomSheetState
@@ -21,6 +22,7 @@ data class AttendanceUiState(
     val buttonStep: ButtonStep = ButtonStep.NONE,
     val canTakeAttendance: Boolean = true,
     val teis: List<SearchTeiModel> = emptyList(),
+    val attendanceStatus: AttendanceStatus? = null,
     val formBuilderState: FormBuilderState = FormBuilderState(),
     val attendanceSummaryState: SummaryState = SummaryState(),
     val bottomSheetState: BottomSheetState.HasItemsState = BottomSheetState.HasItemsState(),

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -18,6 +18,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.saudigitus.semis.attendance.R
 import org.saudigitus.semis.attendance.ui.model.BottomSheetConfirmAction
 import org.saudigitus.semis.attendance.ui.model.BottomSheetType
+import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.data.model.app_config.Attendance
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
@@ -32,6 +33,7 @@ import javax.inject.Inject
 @HiltViewModel
 class AttendanceViewModel @Inject constructor(
     private val formRepository: FormRepository,
+    private val attendanceRepository: AttendanceRepository,
     private val appConfigRepository: AppConfigRepository,
     private val resourceManager: ResourceManager
 ) : ViewModel() {
@@ -135,6 +137,10 @@ class AttendanceViewModel @Inject constructor(
             var updatedToolbar = currentToolbar
 
             val schoolCalendar = appConfigRepository.getSchoolCalendar()
+            val attendanceStatus = attendanceRepository.getAttendanceStatus(
+                uiState.value.program,
+                selectedDate
+            )
 
             if (date != null) {
                 updatedToolbar = currentToolbar.copy(
@@ -156,6 +162,7 @@ class AttendanceViewModel @Inject constructor(
                 it.copy(
                     isLoading = false,
                     toolbarHeaders = updatedToolbar,
+                    attendanceStatus = attendanceStatus,
                     genericsBottomSheetState = currentBulkBottomSheet.copy(
                         imageVector = Icons.Default.Rocket,
                         title = resourceManager.getString(R.string.bulk_attendance),
@@ -200,6 +207,24 @@ class AttendanceViewModel @Inject constructor(
                     )
             }
             attendanceSummary()
+        }
+    }
+
+    private fun save() {
+        viewModelScope.launch {
+            if (uiState.value.attendanceStatus != null
+                && uiState.value.attendanceStatus?.value.toBoolean()
+            ) {
+                attendanceRepository.saveAttendanceStatus(
+                    orgUnit = uiState.value.formBuilderState.orgUnit,
+                    program = uiState.value.program,
+                    date = selectedDate,
+                    filterDetailsState = uiState.value.attendanceSummaryState.filterDetailsState,
+                    attendanceStatus = uiState.value.attendanceStatus!!
+                )
+            } else {
+                saveAttendanceEvents()
+            }
         }
     }
 
@@ -294,6 +319,16 @@ class AttendanceViewModel @Inject constructor(
                 }
             }
 
+            is AttendanceUiEvent.AddAttendanceStatus -> {
+                val currentAttendanceStatus = uiState.value.attendanceStatus
+                _hasCachedData.value = true
+                _uiState.update {
+                    it.copy(
+                        attendanceStatus = currentAttendanceStatus?.copy(value = "${!uiEvent.status}")
+                    )
+                }
+            }
+
             is AttendanceUiEvent.BulkOverrideAttendance -> {
                 if (cachedButtonModel != null) {
                     bulkAttendance(cachedButtonModel!!)
@@ -310,7 +345,7 @@ class AttendanceViewModel @Inject constructor(
                         it.copy(displayBulk = false)
                     }
                 } else {
-                    saveAttendanceEvents()
+                    save()
                     _uiState.update {
                         it.copy(displayDialog = false)
                     }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceStatusSwitch.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceStatusSwitch.kt
@@ -1,0 +1,46 @@
+package org.saudigitus.semis.attendance.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.hisp.dhis.mobile.ui.designsystem.component.Switch
+
+@Composable
+fun AttendanceStatusSwitch(
+    title: String,
+    modifier: Modifier = Modifier,
+    isChecked: Boolean = false,
+    enabled: Boolean = true,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .border(
+                width = 0.25.dp,
+                color = Color.LightGray,
+                shape = RoundedCornerShape(16.dp)
+            )
+            .padding(horizontal = 12.dp)
+            .then(modifier),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(title)
+        Switch(
+            isChecked = isChecked,
+            enabled = enabled,
+            onCheckedChange = onCheckedChange
+        )
+    }
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatus.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatus.kt
@@ -1,0 +1,10 @@
+package org.saudigitus.semis.attendance.ui.model
+
+data class AttendanceStatus(
+    val event: String? = null,
+    val program: String?,
+    val programStage: String?,
+    val dataElement: String?,
+    val displayName: String?,
+    val value: String? = null,
+)

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
@@ -1,0 +1,16 @@
+package org.saudigitus.semis.attendance.ui.repository
+
+import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+
+interface AttendanceRepository {
+
+    suspend fun saveAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        attendanceStatus: AttendanceStatus
+    )
+    suspend fun getAttendanceStatus(program: String, date: String): AttendanceStatus?
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -1,0 +1,86 @@
+package org.saudigitus.semis.attendance.ui.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.dhis2.commons.bindings.dataElement
+import org.hisp.dhis.android.core.D2
+import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
+import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.data.utils.eventsWithTrackedDataValuesByDate
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import org.saudigitus.semis.core.designsystem.utils.UiDefaults.sectionWritingType
+import org.saudigitus.semis.core.form.data.repository.FormRepository
+import org.saudigitus.semis.core.utils.Constants
+
+class AttendanceRepositoryImpl(
+    private val d2: D2,
+    private val appConfigRepository: AppConfigRepository,
+    private val formRepository: FormRepository,
+) : AttendanceRepository {
+    override suspend fun saveAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        attendanceStatus: AttendanceStatus
+    ) = withContext(Dispatchers.IO) {
+        val data = mutableListOf<Pair<String, String?>>()
+        val dataElements = appConfigRepository.getAppConfig(program)
+            ?.filters
+            ?.dataElements
+            ?.filterNotNull() ?: emptyList()
+        val academicYear = appConfigRepository.getSchoolCalendar()
+            ?.academicYear.orEmpty()
+
+        if (dataElements.isNotEmpty() && !filterDetailsState.grade.isNullOrEmpty()
+            && !filterDetailsState.section.isNullOrEmpty()
+        ) {
+            val grade = dataElements.find { it.code == Constants.GRADE }
+            val section = dataElements.find { it.code in sectionWritingType }
+
+            data.add(Pair(grade?.dataElement.orEmpty(), filterDetailsState.grade))
+            data.add(Pair(section?.dataElement.orEmpty(), filterDetailsState.section))
+        }
+
+        data.add(Pair(academicYear, filterDetailsState.academicYear))
+        data.add(Pair(attendanceStatus.dataElement.orEmpty(), attendanceStatus.value))
+
+        formRepository.saveAttendanceStatus(
+            event = attendanceStatus.event,
+            orgUnit = orgUnit,
+            program = attendanceStatus.program.orEmpty(),
+            programStage = attendanceStatus.programStage.orEmpty(),
+            data = data,
+            eventDate = date
+        )
+    }
+
+    override suspend fun getAttendanceStatus(program: String, date: String): AttendanceStatus? =
+        withContext(Dispatchers.IO) {
+            val attendanceStatus = appConfigRepository.getAppConfig(program)
+                ?.attendance
+                ?.attendanceStatus
+
+            if (attendanceStatus == null) return@withContext null
+
+            val dataElement = d2.dataElement(attendanceStatus.status.orEmpty())
+
+            val event = d2.eventsWithTrackedDataValuesByDate(
+                program = attendanceStatus.program.orEmpty(),
+                stage = attendanceStatus.programStage.orEmpty(),
+                date = date
+            )
+
+            val dataValue = event?.trackedEntityDataValues()
+                ?.find { dv -> dv.dataElement() == dataElement?.uid() }
+
+            AttendanceStatus(
+                event = event?.uid(),
+                program = attendanceStatus.program,
+                programStage = attendanceStatus.programStage,
+                dataElement = dataElement?.uid(),
+                displayName = dataElement?.displayFormName(),
+                value = dataValue?.value()
+            )
+        }
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/Attendance.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/Attendance.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.Serializable
 data class Attendance(
     @SerialName("absenceReason")
     val absenceReason: String?,
+    @SerialName("attendanceStatus")
+    val attendanceStatus: AttendanceStatus?,
     @SerialName("enabled")
     val enabled: Boolean?,
     @SerialName("lastUpdate")

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
@@ -1,0 +1,11 @@
+package org.saudigitus.semis.core.data.model.app_config
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AttendanceStatus(
+    val allowAttendanceStatus: Boolean?,
+    val program: String?,
+    val programStage: String?,
+    val status: String?,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
@@ -35,10 +35,21 @@ interface EventRepository {
         orgUnit: String,
         program: String,
         programStage: String,
-        tei: SearchTeiModel,
+        tei: SearchTeiModel? = null,
         data: Map<String, Pair<String, String>>,
-        eventDate: String?,
+        eventDate: String? = null,
     )
+
+    suspend fun saveEvent(
+        event: String?,
+        orgUnit: String,
+        program: String,
+        programStage: String,
+        tei: SearchTeiModel? = null,
+        data: List<Pair<String, String?>>,
+        eventDate: String? = null,
+    )
+
     suspend fun getEvents(
         teiUids: List<String>,
         program: String,

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -22,33 +22,50 @@ class EventRepositoryImpl @Inject constructor(
             .byDisplayName().eq(Constants.DEFAULT).one().blockingGet()?.uid()
 
     private fun createEventProjection(
-        enrollment: String,
+        enrollment: String? = null,
         ou: String,
         program: String,
         programStage: String,
     ): String {
+        val projection = EventCreateProjection.builder()
+            .organisationUnit(ou)
+            .program(program).programStage(programStage)
+            .attributeOptionCombo(getAttributeOptionCombo())
+
         return d2.eventModule().events()
             .blockingAdd(
-                EventCreateProjection.builder()
-                    .organisationUnit(ou)
-                    .program(program).programStage(programStage)
-                    .attributeOptionCombo(getAttributeOptionCombo())
-                    .enrollment(enrollment).build(),
+                if (!enrollment.isNullOrEmpty()) {
+                    projection.enrollment(enrollment).build()
+                } else {
+                    projection.build()
+                }
             )
     }
 
     private fun eventUid(
-        tei: String,
+        tei: String?,
         program: String,
         programStage: String,
         date: String?,
     ): String? {
-        return d2.eventModule().events()
+        val eventsRepo = d2.eventModule().events()
+
+        return if (!tei.isNullOrEmpty()) {
+            eventsRepo
             .byTrackedEntityInstanceUids(listOf(tei))
-            .byProgramUid().eq(program)
-            .byProgramStageUid().eq(programStage)
-            .byEventDate().eq(Date.valueOf(date))
-            .one().blockingGet()?.uid()
+                .byProgramUid().eq(program)
+                .byProgramStageUid().eq(programStage)
+                .byDeleted().isFalse
+                .byEventDate().eq(Date.valueOf(date))
+                .one().blockingGet()?.uid()
+        } else {
+            eventsRepo
+                .byProgramUid().eq(program)
+                .byProgramStageUid().eq(programStage)
+                .byDeleted().isFalse
+                .byEventDate().eq(Date.valueOf(date))
+                .one().blockingGet()?.uid()
+        }
     }
 
     override suspend fun saveEvent(
@@ -56,7 +73,7 @@ class EventRepositoryImpl @Inject constructor(
         orgUnit: String,
         program: String,
         programStage: String,
-        tei: SearchTeiModel,
+        tei: SearchTeiModel?,
         data: Map<String, Pair<String, String>>,
         eventDate: String?
     ) {
@@ -65,12 +82,12 @@ class EventRepositoryImpl @Inject constructor(
 
             try {
                 val uid = event ?: eventUid(
-                    tei.uid(),
+                    tei?.uid(),
                     program,
                     programStage,
                     date
                 ) ?: createEventProjection(
-                    tei.selectedEnrollment?.uid().orEmpty(),
+                    tei?.selectedEnrollment?.uid(),
                     orgUnit,
                     program,
                     programStage,
@@ -87,6 +104,46 @@ class EventRepositoryImpl @Inject constructor(
                     d2.trackedEntityModule().trackedEntityDataValues()
                         .value(uid, secondaryDataValue.first)
                         .blockingSet(secondaryDataValue.second)
+                }
+
+                val repository = d2.eventModule().events().uid(uid)
+                repository.setEventDate(Date.valueOf(date))
+                repository.setStatus(EventStatus.COMPLETED)
+            } catch (e: Exception) {
+                Timber.tag("SAVE_EVENT").e(e)
+            }
+        }
+    }
+
+    override suspend fun saveEvent(
+        event: String?,
+        orgUnit: String,
+        program: String,
+        programStage: String,
+        tei: SearchTeiModel?,
+        data: List<Pair<String, String?>>,
+        eventDate: String?
+    ) {
+        withContext(Dispatchers.IO) {
+            val date = eventDate ?: DateHelper.formatDate(System.currentTimeMillis())!!
+
+            try {
+                val uid = event ?: eventUid(
+                    tei?.uid(),
+                    program,
+                    programStage,
+                    date
+                ) ?: createEventProjection(
+                    tei?.selectedEnrollment?.uid(),
+                    orgUnit,
+                    program,
+                    programStage,
+                )
+
+                for (item in data) {
+                    d2.trackedEntityModule().trackedEntityDataValues()
+                        .value(uid, item.first)
+                        .blockingSet(item.second)
                 }
 
                 val repository = d2.eventModule().events().uid(uid)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Extensions.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Extensions.kt
@@ -6,6 +6,8 @@ import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.option.Option
 import org.saudigitus.semis.core.data.model.Module
 import org.saudigitus.semis.core.data.model.OptionModel
+import org.saudigitus.semis.core.utils.DateHelper
+import java.sql.Date
 
 fun D2.eventsWithTrackedDataValues(
     ou: String,
@@ -17,6 +19,19 @@ fun D2.eventsWithTrackedDataValues(
     .byProgramStageUid().eq(stage)
     .byDeleted().isFalse
     .withTrackedEntityDataValues()
+    .blockingGet()
+
+fun D2.eventsWithTrackedDataValuesByDate(
+    program: String,
+    stage: String,
+    date: String? = DateHelper.formatDate(System.currentTimeMillis())
+): Event? = eventModule().events()
+    .byProgramUid().eq(program)
+    .byProgramStageUid().eq(stage)
+    .byEventDate().eq(Date.valueOf(date))
+    .byDeleted().isFalse
+    .withTrackedEntityDataValues()
+    .one()
     .blockingGet()
 
 fun D2.optionByOptionSet(

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/summary/SummaryDetails.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/summary/SummaryDetails.kt
@@ -1,5 +1,6 @@
 package org.saudigitus.semis.core.designsystem.components.summary
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,7 @@ fun SummaryDetails(
     modifier: Modifier = Modifier,
     state: SummaryState,
     onBulk: (() -> Unit)? = null,
+    content: (@Composable () -> Unit)? = null,
 ) {
     Column(
         modifier = modifier,
@@ -83,6 +85,10 @@ fun SummaryDetails(
                     )
                 }
             }
+        }
+
+        AnimatedVisibility(visible = content != null) {
+            content?.invoke()
         }
     }
 }

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/UiDefaults.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/utils/UiDefaults.kt
@@ -19,6 +19,12 @@ object UiDefaults {
         Constants.CLASS to FilterType.SECTION
     )
 
+    val sectionWritingType = listOf(
+        Constants.SECTION,
+        Constants.SECTION_CLASS,
+        Constants.CLASS
+    )
+
     fun getIconByName(name: String) = when (name) {
         "correct_blue_fill" -> R.drawable.present
         "wrong_red_fill" -> R.drawable.absent

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -17,6 +17,15 @@ interface AttendanceEventRepository {
         attendanceEvents: List<AttendanceEventWithDecorator>
     )
 
+    suspend fun saveAttendanceStatus(
+        event: String? = null,
+        orgUnit: String,
+        program: String,
+        programStage: String,
+        data: List<Pair<String, String?>>,
+        eventDate: String
+    )
+
     suspend fun getAttendanceEvent(
         teiUids: List<String>,
         program: String,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -356,6 +356,24 @@ class FormRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun saveAttendanceStatus(
+        event: String?,
+        orgUnit: String,
+        program: String,
+        programStage: String,
+        data: List<Pair<String, String?>>,
+        eventDate: String
+    ) = withContext(Dispatchers.IO) {
+        eventRepository.saveEvent(
+            event = event,
+            orgUnit = orgUnit,
+            program = program,
+            programStage = programStage,
+            data = data,
+            eventDate = eventDate
+        )
+    }
+
     override suspend fun getAttendanceEvent(
         teiUids: List<String>,
         program: String,


### PR DESCRIPTION
* Implement `AttendanceRepository` for managing attendance status.
* Add `AttendanceStatusSwitch` component and integrate it into `AttendanceScreen`.
* Update `AttendanceViewModel` to handle fetching, updating, and saving global attendance status.
* Enhance `EventRepository` to support saving events without a specific tracked entity instance.
* Extend app configuration models to include `AttendanceStatus` settings.