### PR TITLE
feat: implement global attendance status tracking and summary workflow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,6 @@ org.gradle.configureondemand=true
 android.suppressUnsupportedCompileSdk=32
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/di/AttendanceModule.kt
@@ -8,7 +8,6 @@ import org.hisp.dhis.android.core.D2
 import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
 import org.saudigitus.semis.attendance.ui.repository.AttendanceRepositoryImpl
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
-import org.saudigitus.semis.core.form.data.repository.FormRepository
 import javax.inject.Singleton
 
 @Module
@@ -19,6 +18,5 @@ object AttendanceModule {
     fun provideAttendanceRepository(
         d2: D2,
         appConfigRepository: AppConfigRepository,
-        formRepository: FormRepository
-    ): AttendanceRepository = AttendanceRepositoryImpl(d2, appConfigRepository, formRepository)
+    ): AttendanceRepository = AttendanceRepositoryImpl(d2, appConfigRepository)
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -1,6 +1,5 @@
 package org.saudigitus.semis.attendance.ui
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -49,7 +48,6 @@ import org.hisp.dhis.mobile.ui.designsystem.component.state.rememberListCardStat
 import org.hisp.dhis.mobile.ui.designsystem.theme.Radius
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.hisp.dhis.mobile.ui.designsystem.theme.dropShadow
-import org.saudigitus.semis.attendance.ui.components.AttendanceStatusSwitch
 import org.saudigitus.semis.attendance.ui.components.BulkCard
 import org.saudigitus.semis.attendance.ui.model.BottomSheetConfirmAction
 import org.saudigitus.semis.attendance.ui.model.BottomSheetType
@@ -158,7 +156,9 @@ fun AttendanceScreen(
                 text = {
                     Text(
                         text = if (state.buttonStep == ButtonStep.NONE) {
-                            stringResource(R.string.update)
+                            stringResource(R.string.take_attendance)
+                        } else if (state.allowAttendanceStatus) {
+                            stringResource(R.string.complete_attendance)
                         } else {
                             stringResource(R.string.save)
                         },
@@ -200,17 +200,6 @@ fun AttendanceScreen(
                 ),
             state = state.attendanceSummaryState,
             onBulk = { onEvent(AttendanceUiEvent.ShowBottomSheet(BottomSheetType.BULK)) },
-            content = {
-                if (state.attendanceStatus != null) {
-                    AttendanceStatusSwitch(
-                        title = state.attendanceStatus.displayName.orEmpty(),
-                        isChecked = state.attendanceStatus.value.toBoolean(),
-                        onCheckedChange = {
-                            onEvent(AttendanceUiEvent.AddAttendanceStatus(it))
-                        }
-                    )
-                }
-            }
         )
 
         if (state.isLoading) {
@@ -322,16 +311,28 @@ fun AttendanceScreen(
                             onCardClick = card.first.onCardCLick,
                             listAvatar = card.first.avatar,
                         )
-                        AnimatedVisibility(!state.attendanceStatus?.value.toBoolean()) {
-                            FormContent(
-                                key = tei.uid(),
-                                tei = tei,
-                                type = FormType.ATTENDANCE,
-                                modifier = Modifier.fillMaxWidth(),
-                                state = formState,
-                                onEvent = onFormEvent
-                            )
-                        }
+                        FormContent(
+                            key = tei.uid(),
+                            tei = tei,
+                            type = FormType.ATTENDANCE,
+                            modifier = Modifier.fillMaxWidth(),
+                            state = formState,
+                            onEvent = { formEvent ->
+                                if (
+                                    !state.allowAttendanceStatus &&
+                                    formEvent is FormEvent.UpdateAttendance
+                                ) {
+                                    onEvent(
+                                        AttendanceUiEvent.OnAttendanceClick(
+                                            tei = formEvent.tei,
+                                            buttonModel = formEvent.buttonModel,
+                                        )
+                                    )
+                                } else {
+                                    onFormEvent(formEvent)
+                                }
+                            }
+                        )
                         Spacer(modifier = Modifier.padding(2.dp))
                     }
                 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
@@ -33,11 +33,27 @@ fun AttendanceUi(
     LaunchedEffect(Unit) {
         viewModel.snackbarEvent.collectLatest { message ->
             if (message != null) {
+                formViewModel.resetCacheStatus()
                 snackbarHostState.showSnackbar(
                     message = message,
                     duration = SnackbarDuration.Short
                 )
             }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.syncEvent.collectLatest {
+            syncData()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.errorEvent.collectLatest { message ->
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Long,
+            )
         }
     }
 
@@ -85,6 +101,10 @@ fun AttendanceUi(
                 }
 
                 is AttendanceUiEvent.OnSyncClicked -> syncData()
+                is AttendanceUiEvent.OnAttendanceClick -> {
+                    formViewModel.markAttendanceChanged()
+                    viewModel.handleUiEvent(it)
+                }
                 else -> viewModel.handleUiEvent(it)
             }
         }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
@@ -21,6 +21,7 @@ data class AttendanceUiState(
     val program: String = "",
     val buttonStep: ButtonStep = ButtonStep.NONE,
     val canTakeAttendance: Boolean = true,
+    val allowAttendanceStatus: Boolean = false,
     val teis: List<SearchTeiModel> = emptyList(),
     val attendanceStatus: AttendanceStatus? = null,
     val formBuilderState: FormBuilderState = FormBuilderState(),

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -21,6 +21,7 @@ import org.saudigitus.semis.attendance.ui.model.BottomSheetType
 import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.data.model.app_config.Attendance
+import org.saudigitus.semis.core.data.model.app_config.isEnabledAndConfigured
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
@@ -50,6 +51,12 @@ class AttendanceViewModel @Inject constructor(
 
     private val _snackbarEvent = MutableSharedFlow<String?>()
     val snackbarEvent: SharedFlow<String?> = _snackbarEvent
+
+    private val _syncEvent = MutableSharedFlow<Unit>()
+    val syncEvent: SharedFlow<Unit> = _syncEvent
+
+    private val _errorEvent = MutableSharedFlow<String>()
+    val errorEvent: SharedFlow<String> = _errorEvent
 
     private val _uiState = MutableStateFlow(
         AttendanceUiState(
@@ -107,6 +114,8 @@ class AttendanceViewModel @Inject constructor(
                     isLoading = false,
                     program = program,
                     teis = teis,
+                    allowAttendanceStatus = config?.attendance?.attendanceStatus
+                        .isEnabledAndConfigured(),
                     attendanceSummaryState = currentAttendanceSummaryState.copy(
                         filterDetailsState = filterDetailsState
                     ),
@@ -127,63 +136,74 @@ class AttendanceViewModel @Inject constructor(
         _hasCachedData.value = cached
     }
 
-    private fun loadAttendanceEventsByDate(date: String? = null) {
+    private suspend fun loadAttendanceEventsByDate(date: String? = null) {
         selectedDate = date ?: DateHelper.formatDate(System.currentTimeMillis()).orEmpty()
 
-        viewModelScope.launch {
-            val currentToolbar = uiState.value.toolbarHeaders
-            val currentBulkBottomSheet = uiState.value.genericsBottomSheetState
-            val currentFormState = uiState.value.formBuilderState
-            var updatedToolbar = currentToolbar
+        val currentToolbar = uiState.value.toolbarHeaders
+        val currentBulkBottomSheet = uiState.value.genericsBottomSheetState
+        val currentFormState = uiState.value.formBuilderState
+        var updatedToolbar = currentToolbar
 
-            val schoolCalendar = appConfigRepository.getSchoolCalendar()
-            val attendanceStatus = attendanceRepository.getAttendanceStatus(
-                uiState.value.program,
-                selectedDate
-            )
-
-            if (date != null) {
-                updatedToolbar = currentToolbar.copy(
-                    subtitle = DateHelper.formatDateWithWeekDay(date)
-                )
-            }
-
-            val currentButtonState = formRepository.loadAttendanceEvents(
-                teiUids = studentsIds,
+        val schoolCalendar = appConfigRepository.getSchoolCalendar()
+        val attendanceStatus = attendanceRepository.getAttendanceStatus(
+            orgUnit = uiState.value.formBuilderState.orgUnit,
+            program = uiState.value.program,
+            date = selectedDate,
+            filterDetailsState = uiState.value.attendanceSummaryState.filterDetailsState,
+        ) ?: if (uiState.value.buttonStep != ButtonStep.NONE) {
+            attendanceRepository.createAttendanceStatus(
+                orgUnit = uiState.value.formBuilderState.orgUnit,
                 program = uiState.value.program,
-                programStage = attendanceConfig?.programStage.orEmpty(),
-                dataElement = attendanceConfig?.status.orEmpty(),
-                reasonDataElement = attendanceConfig?.absenceReason.orEmpty(),
-                eventDate = date ?: DateHelper.formatDate(System.currentTimeMillis())
-                    .orEmpty()
+                date = selectedDate,
+                filterDetailsState = uiState.value.attendanceSummaryState.filterDetailsState,
             )
+        } else {
+            null
+        }
 
-            _uiState.update {
-                it.copy(
-                    isLoading = false,
-                    toolbarHeaders = updatedToolbar,
-                    attendanceStatus = attendanceStatus,
-                    genericsBottomSheetState = currentBulkBottomSheet.copy(
-                        imageVector = Icons.Default.Rocket,
-                        title = resourceManager.getString(R.string.bulk_attendance),
-                        items = currentButtonState.buttons
-                    ),
-                    formBuilderState = currentFormState.copy(
-                        date = selectedDate
-                    ),
-                    canTakeAttendance = appConfigRepository.allowedCalenderYearDates(
-                        DateHelper.convertDateToMilliseconds(selectedDate),
-                        schoolCalendar
-                    )
+        if (date != null) {
+            updatedToolbar = currentToolbar.copy(
+                subtitle = DateHelper.formatDateWithWeekDay(date)
+            )
+        }
+
+        val currentButtonState = formRepository.loadAttendanceEvents(
+            teiUids = studentsIds,
+            program = uiState.value.program,
+            programStage = attendanceConfig?.programStage.orEmpty(),
+            dataElement = attendanceConfig?.status.orEmpty(),
+            reasonDataElement = attendanceConfig?.absenceReason.orEmpty(),
+            eventDate = selectedDate,
+        )
+
+        _uiState.update {
+            it.copy(
+                isLoading = false,
+                toolbarHeaders = updatedToolbar,
+                attendanceStatus = attendanceStatus,
+                genericsBottomSheetState = currentBulkBottomSheet.copy(
+                    imageVector = Icons.Default.Rocket,
+                    title = resourceManager.getString(R.string.bulk_attendance),
+                    items = currentButtonState.buttons
+                ),
+                formBuilderState = currentFormState.copy(
+                    date = selectedDate
+                ),
+                canTakeAttendance = appConfigRepository.allowedCalenderYearDates(
+                    DateHelper.convertDateToMilliseconds(selectedDate),
+                    schoolCalendar
                 )
-            }
+            )
         }
     }
 
     private fun attendanceSummary() {
         viewModelScope.launch {
             val attendanceSummaryState = uiState.value.attendanceSummaryState
-            formRepository.attendanceSummary(uiState.value.program) { summaries ->
+            formRepository.attendanceSummary(
+                program = uiState.value.program,
+                totalLearners = studentsIds.size,
+            ) { summaries ->
                 _uiState.update {
                     it.copy(
                         attendanceSummaryState = attendanceSummaryState.copy(
@@ -211,19 +231,41 @@ class AttendanceViewModel @Inject constructor(
     }
 
     private fun save() {
+        saveAttendanceEvents()
+    }
+
+    private fun startAttendance() {
         viewModelScope.launch {
-            if (uiState.value.attendanceStatus != null
-                && uiState.value.attendanceStatus?.value.toBoolean()
-            ) {
-                attendanceRepository.saveAttendanceStatus(
-                    orgUnit = uiState.value.formBuilderState.orgUnit,
-                    program = uiState.value.program,
-                    date = selectedDate,
-                    filterDetailsState = uiState.value.attendanceSummaryState.filterDetailsState,
-                    attendanceStatus = uiState.value.attendanceStatus!!
-                )
-            } else {
-                saveAttendanceEvents()
+            val current = uiState.value
+
+            runCatching {
+                if (current.allowAttendanceStatus) {
+                    attendanceRepository.createAttendanceStatus(
+                        orgUnit = current.formBuilderState.orgUnit,
+                        program = current.program,
+                        date = selectedDate,
+                        filterDetailsState = current.attendanceSummaryState.filterDetailsState,
+                    ) ?: error("Attendance status event could not be created")
+                } else {
+                    null
+                }
+            }.onSuccess { attendanceStatus ->
+                formRepository.allowFormEdition(true)
+                _uiState.update {
+                    it.copy(
+                        buttonStep = ButtonStep.EDITING,
+                        attendanceStatus = attendanceStatus,
+                        attendanceSummaryState = it.attendanceSummaryState.copy(
+                            enableBulk = true,
+                        ),
+                    )
+                }
+            }.onFailure { error ->
+                val message = friendlyErrorMessage(error)
+                _uiState.update {
+                    it.copy(errorMessage = message)
+                }
+                _errorEvent.emit(message)
             }
         }
     }
@@ -238,52 +280,77 @@ class AttendanceViewModel @Inject constructor(
                     programStage = attendanceConfig?.programStage.orEmpty(),
                     attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents
                 )
-            }.onSuccess {
-                _uiState.update {
-                    it.copy(buttonStep = ButtonStep.NONE)
+                if (current.allowAttendanceStatus) {
+                    attendanceRepository.completeAttendanceStatus(
+                        orgUnit = current.formBuilderState.orgUnit,
+                        program = current.program,
+                        date = selectedDate,
+                        filterDetailsState = current.attendanceSummaryState.filterDetailsState,
+                        totalLearners = studentsIds.size,
+                        attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents,
+                    ) ?: error("Attendance status event could not be completed")
+                } else {
+                    null
                 }
+            }.onSuccess { completedAttendanceStatus ->
                 formRepository.allowFormEdition(false)
-                loadAttendanceEventsByDate(selectedDate)
-                _snackbarEvent.emit(resourceManager.getString(R.string.attendance_saved))
-            }.onFailure { error ->
-                val friendlyMessage = when (error) {
-                    is D2Error -> {
-                        "${error.errorCode()} – ${
-                            error.message ?: resourceManager
-                                .getString(R.string.error_unexpected)
-                        }"
-                    }
-
-                    else -> error.message ?: resourceManager
-                        .getString(R.string.error_unexpected)
-                }
-
                 _uiState.update {
-                    it.copy(errorMessage = friendlyMessage)
+                    it.copy(
+                        buttonStep = ButtonStep.NONE,
+                        attendanceStatus = completedAttendanceStatus ?: it.attendanceStatus,
+                        attendanceSummaryState = it.attendanceSummaryState.copy(
+                            enableBulk = false,
+                        ),
+                    )
                 }
+                loadAttendanceEventsByDate(selectedDate)
+                _hasCachedData.value = false
+                _snackbarEvent.emit(resourceManager.getString(R.string.attendance_saved))
+                _syncEvent.emit(Unit)
+            }.onFailure { error ->
+                val message = friendlyErrorMessage(error)
+                _uiState.update {
+                    it.copy(errorMessage = message)
+                }
+                _errorEvent.emit(message)
             }
         }
+    }
+
+    private fun friendlyErrorMessage(error: Throwable) = when (error) {
+        is D2Error -> {
+            "${error.errorCode()} – ${
+                error.message ?: resourceManager.getString(R.string.error_unexpected)
+            }"
+        }
+
+        else -> error.message ?: resourceManager.getString(R.string.error_unexpected)
     }
 
     fun handleUiEvent(uiEvent: AttendanceUiEvent) {
         when (uiEvent) {
             is AttendanceUiEvent.OnDateSelect -> {
-                loadAttendanceEventsByDate(uiEvent.date)
-                attendanceSummary()
+                viewModelScope.launch {
+                    loadAttendanceEventsByDate(uiEvent.date)
+                    attendanceSummary()
+                }
             }
 
             is AttendanceUiEvent.OnEditClicked -> {
-                val currentAttendanceSummaryState = uiState.value.attendanceSummaryState
+                startAttendance()
+            }
 
-                formRepository.allowFormEdition(true)
-
-                _uiState.update {
-                    it.copy(
-                        buttonStep = ButtonStep.EDITING,
-                        attendanceSummaryState = currentAttendanceSummaryState.copy(
-                            enableBulk = it.buttonStep != ButtonStep.NONE
-                        ),
-                    )
+            is AttendanceUiEvent.OnAttendanceClick -> {
+                if (!uiState.value.allowAttendanceStatus) {
+                    viewModelScope.launch {
+                        formRepository.updateAttendanceEvent(
+                            eventDate = selectedDate,
+                            tei = uiEvent.tei,
+                            buttonModel = uiEvent.buttonModel,
+                        )
+                        _hasCachedData.value = true
+                        attendanceSummary()
+                    }
                 }
             }
 
@@ -316,16 +383,6 @@ class AttendanceViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(displayBulk = false)
                     }
-                }
-            }
-
-            is AttendanceUiEvent.AddAttendanceStatus -> {
-                val currentAttendanceStatus = uiState.value.attendanceStatus
-                _hasCachedData.value = true
-                _uiState.update {
-                    it.copy(
-                        attendanceStatus = currentAttendanceStatus?.copy(value = "${!uiEvent.status}")
-                    )
                 }
             }
 

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatus.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatus.kt
@@ -1,10 +1,10 @@
 package org.saudigitus.semis.attendance.ui.model
 
+import org.hisp.dhis.android.core.event.EventStatus
+
 data class AttendanceStatus(
-    val event: String? = null,
+    val event: String,
     val program: String?,
     val programStage: String?,
-    val dataElement: String?,
-    val displayName: String?,
-    val value: String? = null,
+    val status: EventStatus?,
 )

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceSummaryCounts.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceSummaryCounts.kt
@@ -1,0 +1,26 @@
+package org.saudigitus.semis.attendance.ui.model
+
+internal data class AttendanceSummaryCounts(
+    val totalLearners: Int,
+    val totalAbsences: Int,
+    val statusCounts: Map<String, Int>,
+    val presentLearners: Int,
+)
+
+internal fun attendanceSummaryCounts(
+    totalLearners: Int,
+    configuredStatusCodes: List<String>,
+    attendanceValues: List<String>,
+): AttendanceSummaryCounts {
+    val statusCounts = configuredStatusCodes
+        .distinct()
+        .associateWith { status -> attendanceValues.count { it == status } }
+    val totalAbsences = statusCounts.values.sum()
+
+    return AttendanceSummaryCounts(
+        totalLearners = totalLearners,
+        totalAbsences = totalAbsences,
+        statusCounts = statusCounts,
+        presentLearners = (totalLearners - totalAbsences).coerceAtLeast(0),
+    )
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
@@ -2,15 +2,30 @@ package org.saudigitus.semis.attendance.ui.repository
 
 import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
 
 interface AttendanceRepository {
 
-    suspend fun saveAttendanceStatus(
+    suspend fun createAttendanceStatus(
         orgUnit: String,
         program: String,
         date: String,
         filterDetailsState: FilterDetailsState,
-        attendanceStatus: AttendanceStatus
-    )
-    suspend fun getAttendanceStatus(program: String, date: String): AttendanceStatus?
+    ): AttendanceStatus?
+
+    suspend fun completeAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ): AttendanceStatus?
+
+    suspend fun getAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+    ): AttendanceStatus?
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -2,85 +2,297 @@ package org.saudigitus.semis.attendance.ui.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.dhis2.commons.bindings.dataElement
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.dataelement.DataElement
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.event.EventCreateProjection
+import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
+import org.saudigitus.semis.attendance.ui.model.attendanceSummaryCounts
+import org.saudigitus.semis.core.data.model.app_config.StatusOption
+import org.saudigitus.semis.core.data.model.app_config.isEnabledAndConfigured
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
-import org.saudigitus.semis.core.data.utils.eventsWithTrackedDataValuesByDate
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.sectionWritingType
-import org.saudigitus.semis.core.form.data.repository.FormRepository
 import org.saudigitus.semis.core.utils.Constants
+import java.sql.Date
 
 class AttendanceRepositoryImpl(
     private val d2: D2,
     private val appConfigRepository: AppConfigRepository,
-    private val formRepository: FormRepository,
 ) : AttendanceRepository {
-    override suspend fun saveAttendanceStatus(
+
+    override suspend fun createAttendanceStatus(
         orgUnit: String,
         program: String,
         date: String,
         filterDetailsState: FilterDetailsState,
-        attendanceStatus: AttendanceStatus
-    ) = withContext(Dispatchers.IO) {
-        val data = mutableListOf<Pair<String, String?>>()
-        val dataElements = appConfigRepository.getAppConfig(program)
-            ?.filters
-            ?.dataElements
-            ?.filterNotNull() ?: emptyList()
-        val academicYear = appConfigRepository.getSchoolCalendar()
-            ?.academicYear.orEmpty()
-
-        if (dataElements.isNotEmpty() && !filterDetailsState.grade.isNullOrEmpty()
-            && !filterDetailsState.section.isNullOrEmpty()
-        ) {
-            val grade = dataElements.find { it.code == Constants.GRADE }
-            val section = dataElements.find { it.code in sectionWritingType }
-
-            data.add(Pair(grade?.dataElement.orEmpty(), filterDetailsState.grade))
-            data.add(Pair(section?.dataElement.orEmpty(), filterDetailsState.section))
+    ): AttendanceStatus? = withContext(Dispatchers.IO) {
+        getAttendanceStatus(orgUnit, program, date, filterDetailsState)?.let {
+            return@withContext it
         }
 
-        data.add(Pair(academicYear, filterDetailsState.academicYear))
-        data.add(Pair(attendanceStatus.dataElement.orEmpty(), attendanceStatus.value))
+        val config = attendanceStatusConfig(program) ?: return@withContext null
+        val eventProgram = config.program.orEmpty()
+        val programStage = config.programStage.orEmpty()
 
-        formRepository.saveAttendanceStatus(
-            event = attendanceStatus.event,
-            orgUnit = orgUnit,
-            program = attendanceStatus.program.orEmpty(),
-            programStage = attendanceStatus.programStage.orEmpty(),
-            data = data,
-            eventDate = date
+        if (eventProgram.isEmpty() || programStage.isEmpty()) return@withContext null
+
+        val event = d2.eventModule().events().blockingAdd(
+            EventCreateProjection.builder()
+                .organisationUnit(orgUnit)
+                .program(eventProgram)
+                .programStage(programStage)
+                .attributeOptionCombo(defaultAttributeOptionCombo())
+                .build()
+        )
+
+        contextValues(program, filterDetailsState).forEach { (dataElement, value) ->
+            d2.trackedEntityModule().trackedEntityDataValues()
+                .value(event, dataElement)
+                .blockingSet(value)
+        }
+
+        d2.eventModule().events().uid(event).apply {
+            setEventDate(Date.valueOf(date))
+            setStatus(EventStatus.ACTIVE)
+        }
+
+        AttendanceStatus(
+            event = event,
+            program = eventProgram,
+            programStage = programStage,
+            status = EventStatus.ACTIVE,
         )
     }
 
-    override suspend fun getAttendanceStatus(program: String, date: String): AttendanceStatus? =
-        withContext(Dispatchers.IO) {
-            val attendanceStatus = appConfigRepository.getAppConfig(program)
-                ?.attendance
-                ?.attendanceStatus
+    override suspend fun completeAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ): AttendanceStatus? = withContext(Dispatchers.IO) {
+        val attendanceStatus = getAttendanceStatus(
+            orgUnit,
+            program,
+            date,
+            filterDetailsState,
+        ) ?: createAttendanceStatus(
+            orgUnit,
+            program,
+            date,
+            filterDetailsState,
+        ) ?: return@withContext null
 
-            if (attendanceStatus == null) return@withContext null
+        val summary = summaryValues(
+            program = program,
+            programStage = attendanceStatus.programStage.orEmpty(),
+            totalLearners = totalLearners,
+            attendanceEvents = attendanceEvents,
+        )
 
-            val dataElement = d2.dataElement(attendanceStatus.status.orEmpty())
+        (contextValues(program, filterDetailsState) + summary)
+            .distinctBy { it.first }
+            .forEach { (dataElement, value) ->
+                d2.trackedEntityModule().trackedEntityDataValues()
+                    .value(attendanceStatus.event, dataElement)
+                    .blockingSet(value)
+            }
 
-            val event = d2.eventsWithTrackedDataValuesByDate(
-                program = attendanceStatus.program.orEmpty(),
-                stage = attendanceStatus.programStage.orEmpty(),
-                date = date
+        d2.eventModule().events().uid(attendanceStatus.event)
+            .setStatus(EventStatus.COMPLETED)
+
+        attendanceStatus.copy(status = EventStatus.COMPLETED)
+    }
+
+    override suspend fun getAttendanceStatus(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+    ): AttendanceStatus? = withContext(Dispatchers.IO) {
+        val config = attendanceStatusConfig(program) ?: return@withContext null
+        val eventProgram = config.program.orEmpty()
+        val programStage = config.programStage.orEmpty()
+
+        if (eventProgram.isEmpty() || programStage.isEmpty()) return@withContext null
+
+        val contextValues = contextValues(program, filterDetailsState)
+        val event = d2.eventModule().events()
+            .byOrganisationUnitUid().eq(orgUnit)
+            .byProgramUid().eq(eventProgram)
+            .byProgramStageUid().eq(programStage)
+            .byEventDate().eq(Date.valueOf(date))
+            .byDeleted().isFalse
+            .withTrackedEntityDataValues()
+            .blockingGet()
+            .firstOrNull { it.matches(contextValues) }
+            ?: return@withContext null
+
+        AttendanceStatus(
+            event = event.uid(),
+            program = eventProgram,
+            programStage = programStage,
+            status = event.status(),
+        )
+    }
+
+    private suspend fun contextValues(
+        program: String,
+        filterDetailsState: FilterDetailsState,
+    ): List<Pair<String, String>> {
+        val appConfig = appConfigRepository.getAppConfig(program)
+        val filterDataElements = appConfig?.filters?.dataElements
+            ?.filterNotNull()
+            .orEmpty()
+        val academicYear = appConfigRepository.getSchoolCalendar()?.academicYear
+        val grade = filterDataElements.find { it.code == Constants.GRADE }?.dataElement
+        val section = filterDataElements.find { it.code in sectionWritingType }?.dataElement
+
+        return listOfNotNull(
+            contextValue(academicYear, filterDetailsState.academicYear),
+            contextValue(grade, filterDetailsState.grade),
+            contextValue(section, filterDetailsState.section),
+        )
+    }
+
+    private suspend fun summaryValues(
+        program: String,
+        programStage: String,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ): List<Pair<String, String>> {
+        val attendance = appConfigRepository.getAppConfig(program)?.attendance
+        val configuredStatuses = attendance?.statusOptions
+            ?.filterNotNull()
+            .orEmpty()
+        val nonPresentStatuses = configuredStatuses
+            .filterNot { it.isPresent() }
+            .distinctBy { it.code }
+        val summaryCounts = attendanceSummaryCounts(
+            totalLearners = totalLearners,
+            configuredStatusCodes = nonPresentStatuses.mapNotNull { it.code },
+            attendanceValues = attendanceEvents.mapNotNull { it.event?.value },
+        )
+        val stageDataElements = programStageDataElements(programStage)
+        val values = linkedMapOf<String, String>()
+        val attendanceStatusConfig = attendance?.attendanceStatus
+            ?: error("Attendance status configuration is missing")
+        val totalAbsencesDataElement = attendanceStatusConfig.totalAbsences
+            ?.takeIf { it.isNotBlank() }
+            ?: error("Attendance status total absences data element is missing")
+        val totalRecordsDataElement = attendanceStatusConfig.totalRecords
+            ?.takeIf { it.isNotBlank() }
+            ?: error("Attendance status total records data element is missing")
+
+        values[totalAbsencesDataElement] = summaryCounts.totalAbsences.toString()
+        values[totalRecordsDataElement] = summaryCounts.totalLearners.toString()
+
+        nonPresentStatuses.forEach { status ->
+            val dataElement = resolveDataElement(
+                stageDataElements,
+                listOfNotNull(status.configKey, status.key, status.code),
             )
-
-            val dataValue = event?.trackedEntityDataValues()
-                ?.find { dv -> dv.dataElement() == dataElement?.uid() }
-
-            AttendanceStatus(
-                event = event?.uid(),
-                program = attendanceStatus.program,
-                programStage = attendanceStatus.programStage,
-                dataElement = dataElement?.uid(),
-                displayName = dataElement?.displayFormName(),
-                value = dataValue?.value()
-            )
+            dataElement?.let {
+                values[it.uid()] = (summaryCounts.statusCounts[status.code] ?: 0).toString()
+            }
         }
+
+        val presentStatus = configuredStatuses.firstOrNull { it.isPresent() }
+        resolveDataElement(
+            stageDataElements,
+            listOfNotNull(
+                presentStatus?.configKey,
+                presentStatus?.key,
+                presentStatus?.code,
+                PRESENT_KEY,
+            ),
+        )?.let {
+            values[it.uid()] = summaryCounts.presentLearners.toString()
+        }
+
+        return values.map { it.key to it.value }
+    }
+
+    private fun programStageDataElements(programStage: String): List<DataElement> =
+        d2.programModule().programStageDataElements()
+            .byProgramStage().eq(programStage)
+            .blockingGet()
+            .mapNotNull { it.dataElement()?.uid() }
+            .distinct()
+            .mapNotNull { d2.dataElementModule().dataElements().uid(it).blockingGet() }
+
+    private fun resolveDataElement(
+        dataElements: List<DataElement>,
+        identifiers: List<String>,
+        minimumPartialLength: Int = 1,
+    ): DataElement? {
+        val normalizedIdentifiers = identifiers
+            .map(::normalize)
+            .filter { it.isNotEmpty() }
+
+        return dataElements.firstOrNull { dataElement ->
+            dataElement.identifiers().any { it in normalizedIdentifiers }
+        } ?: dataElements.firstOrNull { dataElement ->
+            dataElement.identifiers().any { metadataIdentifier ->
+                normalizedIdentifiers
+                    .filter { it.length >= minimumPartialLength }
+                    .any { identifier ->
+                        metadataIdentifier.contains(identifier) || identifier.contains(
+                            metadataIdentifier
+                        )
+                    }
+            }
+        }
+    }
+
+    private fun DataElement.identifiers() = listOfNotNull(
+        uid(),
+        code(),
+        displayName(),
+        displayFormName(),
+    ).map(::normalize)
+
+    private fun Event.matches(contextValues: List<Pair<String, String>>) =
+        contextValues.all { (dataElement, value) ->
+            trackedEntityDataValues().orEmpty().any {
+                it.dataElement() == dataElement && it.value() == value
+            }
+        }
+
+    private fun contextValue(dataElement: String?, value: String?): Pair<String, String>? =
+        if (dataElement.isNullOrBlank() || value.isNullOrBlank()) {
+            null
+        } else {
+            dataElement to value
+        }
+
+    private fun StatusOption.isPresent() =
+        key.equals(PRESENT_KEY, ignoreCase = true) ||
+            code.equals(PRESENT_KEY, ignoreCase = true)
+
+    private fun normalize(value: String) = value
+        .lowercase()
+        .filter(Char::isLetterOrDigit)
+
+    private suspend fun attendanceStatusConfig(program: String) =
+        appConfigRepository.getAppConfig(program)
+            ?.attendance
+            ?.attendanceStatus
+            ?.takeIf { it.isEnabledAndConfigured() }
+
+    private fun defaultAttributeOptionCombo() =
+        d2.categoryModule().categoryOptionCombos()
+            .byDisplayName().eq(Constants.DEFAULT)
+            .one()
+            .blockingGet()
+            ?.uid()
+
+    private companion object {
+        const val PRESENT_KEY = "present"
+
+    }
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/utils/AttendanceExtensions.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/utils/AttendanceExtensions.kt
@@ -50,5 +50,6 @@ fun AttendanceButtonModel.withProps(
     enabled = this.enabled,
     icon = icon,
     iconName = iconName,
-    color = iconColor
+    color = iconColor,
+    isAbsence = this.isAbsence,
 )

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceSummaryCountsTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceSummaryCountsTest.kt
@@ -1,0 +1,45 @@
+package org.saudigitus.semis.attendance.ui.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AttendanceSummaryCountsTest {
+
+    @Test
+    fun `present learners exclude all configured non-present statuses`() {
+        val summary = attendanceSummaryCounts(
+            totalLearners = 10,
+            configuredStatusCodes = listOf("ABSENT", "LATE", "EXCUSED"),
+            attendanceValues = listOf("ABSENT", "ABSENT", "LATE"),
+        )
+
+        assertEquals(10, summary.totalLearners)
+        assertEquals(3, summary.totalAbsences)
+        assertEquals(2, summary.statusCounts["ABSENT"])
+        assertEquals(1, summary.statusCounts["LATE"])
+        assertEquals(0, summary.statusCounts["EXCUSED"])
+        assertEquals(7, summary.presentLearners)
+    }
+
+    @Test
+    fun `unknown attendance values do not reduce present learners`() {
+        val summary = attendanceSummaryCounts(
+            totalLearners = 4,
+            configuredStatusCodes = listOf("ABSENT"),
+            attendanceValues = listOf("ABSENT", "UNKNOWN"),
+        )
+
+        assertEquals(3, summary.presentLearners)
+    }
+
+    @Test
+    fun `all learners are present when there are no non-present events`() {
+        val summary = attendanceSummaryCounts(
+            totalLearners = 5,
+            configuredStatusCodes = listOf("ABSENT", "LATE"),
+            attendanceValues = emptyList(),
+        )
+
+        assertEquals(5, summary.presentLearners)
+    }
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
@@ -1,11 +1,27 @@
 package org.saudigitus.semis.core.data.model.app_config
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class AttendanceStatus(
-    val allowAttendanceStatus: Boolean?,
-    val program: String?,
-    val programStage: String?,
-    val status: String?,
+    val allowAttendanceStatus: Boolean? = null,
+    val program: String? = null,
+    val programStage: String? = null,
+    @JsonNames("totalAbsencesDataElement")
+    val totalAbsences: String? = null,
+    @JsonNames("totalRecordsDataElement")
+    val totalRecords: String? = null,
 )
+
+fun AttendanceStatus?.isEnabledAndConfigured(): Boolean {
+    val config = this ?: return false
+
+    return config.allowAttendanceStatus == true &&
+        !config.program.isNullOrBlank() &&
+        !config.programStage.isNullOrBlank() &&
+        !config.totalAbsences.isNullOrBlank() &&
+        !config.totalRecords.isNullOrBlank()
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
@@ -64,4 +64,6 @@ interface EventRepository {
         dataElement: String,
         teis: List<String>,
     ): List<Event>
+
+    suspend fun deleteEvent(event: String)
 }

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -100,10 +100,10 @@ class EventRepositoryImpl @Inject constructor(
                     .value(uid, primaryDataValue.first)
                     .blockingSet(primaryDataValue.second)
 
-                if (secondaryDataValue != null && secondaryDataValue.second.isNotEmpty()) {
+                if (secondaryDataValue != null && secondaryDataValue.first.isNotEmpty()) {
                     d2.trackedEntityModule().trackedEntityDataValues()
                         .value(uid, secondaryDataValue.first)
-                        .blockingSet(secondaryDataValue.second)
+                        .blockingSet(secondaryDataValue.second.takeIf { it.isNotEmpty() })
                 }
 
                 val repository = d2.eventModule().events().uid(uid)
@@ -191,5 +191,9 @@ class EventRepositoryImpl @Inject constructor(
             .byProgramStageUid().eq(programStage)
             .withTrackedEntityDataValues()
             .blockingGet()
+    }
+
+    override suspend fun deleteEvent(event: String) = withContext(Dispatchers.IO) {
+        d2.eventModule().events().uid(event).delete().blockingAwait()
     }
 }

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatusTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatusTest.kt
@@ -1,0 +1,47 @@
+package org.saudigitus.semis.core.data.model.app_config
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.utils.JsonMapper
+
+class AttendanceStatusTest {
+
+    @Test
+    fun `reads total data elements from attendance status property names`() {
+        val status = JsonMapper.json.decodeFromString<AttendanceStatus>(
+            """{"totalAbsences":"absences","totalRecords":"records"}"""
+        )
+
+        assertEquals("absences", status.totalAbsences)
+        assertEquals("records", status.totalRecords)
+    }
+
+    @Test
+    fun `reads legacy total data element property names`() {
+        val status = JsonMapper.json.decodeFromString<AttendanceStatus>(
+            """{
+                "totalAbsencesDataElement":"absences",
+                "totalRecordsDataElement":"records"
+            }""".trimIndent()
+        )
+
+        assertEquals("absences", status.totalAbsences)
+        assertEquals("records", status.totalRecords)
+    }
+
+    @Test
+    fun `uses attendance status flow only when enabled configuration is complete`() {
+        val complete = AttendanceStatus(
+            allowAttendanceStatus = true,
+            program = "program",
+            programStage = "stage",
+            totalAbsences = "absences",
+            totalRecords = "records",
+        )
+
+        assertEquals(true, complete.isEnabledAndConfigured())
+        assertEquals(false, complete.copy(totalRecords = null).isEnabledAndConfigured())
+        assertEquals(false, complete.copy(allowAttendanceStatus = false).isEnabledAndConfigured())
+        assertEquals(false, null.isEnabledAndConfigured())
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButton.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/AttendanceButton.kt
@@ -22,6 +22,7 @@ import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonM
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.GRAY
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults.getIconByName
+import org.saudigitus.semis.core.designsystem.theme.white
 
 @Composable
 fun AttendanceButton(
@@ -46,10 +47,15 @@ fun AttendanceButton(
         ) {
             itemsIndexed(state.buttons) { _, item ->
                 val event = state.attendanceEvents.find { it.event?.tei == key }
+                val isSelected = if (item.code == null) {
+                    event == null
+                } else {
+                    event?.event?.value == item.code
+                }
 
                 IconButton(
                     onClick = {
-                        onClick.invoke( item)
+                        onClick.invoke(item)
                     },
                     enabled = item.enabled,
                     modifier = Modifier
@@ -60,11 +66,13 @@ fun AttendanceButton(
                         )
                         .size(45.dp),
                     colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = if (event != null && event.event?.value == item.code) {
-                            event.decorator?.containerColor ?: Color.White
+                        containerColor = if (isSelected) {
+                            event?.decorator?.containerColor
+                                ?: item.color
+                                ?: UiDefaults.getAttendanceStatusColor(item.key)
                         } else Color.White,
-                        contentColor = if (event != null && event.event?.value == item.code) {
-                            Color(event.decorator?.contentColor ?: GRAY)
+                        contentColor = if (isSelected) {
+                            Color(event?.decorator?.contentColor ?: white)
                         } else {
                             item.color
                                 ?: UiDefaults.getAttendanceStatusColor(item.code.orEmpty())
@@ -79,23 +87,46 @@ fun AttendanceButton(
                 }
             }
         }
-    } else if (state.attendanceEvents.isEmpty()) {
-        Icon(
-            modifier = modifier.then(Modifier.size(45.dp)),
-            imageVector = Icons.AutoMirrored.Filled.Help,
-            contentDescription = null,
-            tint = Color.LightGray
-        )
     } else {
         val event = state.attendanceEvents.find { it.event?.tei == key }
 
         if (event == null) {
-            Icon(
-                modifier = modifier.then(Modifier.size(45.dp)),
-                imageVector = Icons.AutoMirrored.Filled.Help,
-                contentDescription = null,
-                tint = Color.LightGray
-            )
+            val present = state.buttons.firstOrNull { it.code == null }
+
+            if (present == null) {
+                Icon(
+                    modifier = modifier.then(Modifier.size(45.dp)),
+                    imageVector = Icons.AutoMirrored.Filled.Help,
+                    contentDescription = null,
+                    tint = Color.LightGray
+                )
+            } else {
+                IconButton(
+                    onClick = {},
+                    modifier = modifier.then(
+                        Modifier
+                            .border(
+                                width = (0.15).dp,
+                                color = Color.LightGray,
+                                shape = RoundedCornerShape(100.dp)
+                            )
+                            .size(45.dp)
+                    ),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = present.color
+                            ?: UiDefaults.getAttendanceStatusColor(present.key),
+                        contentColor = Color.White,
+                    )
+                ) {
+                    Icon(
+                        imageVector = present.icon
+                            ?: ImageVector.vectorResource(
+                                getIconByName(present.iconName.orEmpty())
+                            ),
+                        contentDescription = present.name,
+                    )
+                }
+            }
         } else {
             IconButton(
                 onClick = {},

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonModel.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/attendance/model/AttendanceButtonModel.kt
@@ -14,6 +14,7 @@ data class AttendanceButtonModel(
     val enabled: Boolean = true,
     val color: Color? = null,
     val order: Int? = null,
+    val isAbsence: Boolean = false,
 ) {
     override fun toString(): String {
         return "AttendanceButtonModel(key='$key')"

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="marked_follow_up">Marked for follow-up</string>
     <string name="sync_error_title">Sync Error</string>
     <string name="update">Update</string>
+    <string name="take_attendance">Take Attendance</string>
+    <string name="complete_attendance">Complete Attendance</string>
     <string name="app_not_properly_config">App not configured properly. Please contact System Administrator</string>
     <string name="attendance_saved">Attendance saved successfully</string>
     <string name="not_saved">Not saved</string>

--- a/semis/core/form/src/androidTest/java/org/saudigitus/semis/core/form/ExampleInstrumentedTest.kt
+++ b/semis/core/form/src/androidTest/java/org/saudigitus/semis/core/form/ExampleInstrumentedTest.kt
@@ -1,0 +1,24 @@
+package org.saudigitus.semis.core.form
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ExampleInstrumentedTest {
+    @Test
+    fun useAppContext() {
+        // Context of the app under test.
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        assertEquals("rg.saudigitus.semis.core.form.test", appContext.packageName)
+    }
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/model/FormFieldState.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/model/FormFieldState.kt
@@ -14,10 +14,11 @@ data class FormFieldState(
     val rendered: Boolean = true,
     val enabled: Boolean = true,
     val isAttendanceType: Boolean = false,
+    val isAttendanceReason: Boolean = false,
     val hasError: Boolean = false,
     val errorMessage: String? = null
 ) {
     override fun toString(): String {
-        return "FormFieldState(eventUid=$eventUid, dataElementUid='$dataElementUid', label='$label', valueType=$valueType, value=$value, optionSet=$optionSet, mandatory=$mandatory, rendered=$rendered, enabled=$enabled, isAttendanceType=$isAttendanceType, hasError=$hasError, errorMessage=$errorMessage)"
+        return "FormFieldState(eventUid=$eventUid, dataElementUid='$dataElementUid', label='$label', valueType=$valueType, value=$value, optionSet=$optionSet, mandatory=$mandatory, rendered=$rendered, enabled=$enabled, isAttendanceType=$isAttendanceType, isAttendanceReason=$isAttendanceReason, hasError=$hasError, errorMessage=$errorMessage)"
     }
 }

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -54,6 +54,7 @@ interface AttendanceEventRepository {
 
     suspend fun attendanceSummary(
         program: String,
+        totalLearners: Int,
         getSummaries: (List<BottomSheetModel>) -> Unit
     )
 }

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceOptionRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceOptionRepositoryImpl.kt
@@ -2,6 +2,7 @@ package org.saudigitus.semis.core.form.data.repository.impl
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.saudigitus.semis.core.data.model.app_config.isEnabledAndConfigured
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
 import org.saudigitus.semis.core.data.repository.OptionRepository
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
@@ -16,37 +17,65 @@ internal class AttendanceOptionRepositoryImpl @Inject constructor(
 ) : AttendanceOptionRepository {
     override suspend fun getAttendanceStatusOptions(program: String) =
         withContext(Dispatchers.IO) {
-        val config = appConfigRepository.getAppConfig(program)
-        val optionsCode = config?.attendance?.statusOptions
-            ?.mapNotNull { it?.code?.trim() }
-            ?.filterNot { it.isEmpty() } ?: emptyList()
+            val config = appConfigRepository.getAppConfig(program)
+            val optionsCode = config?.attendance?.statusOptions
+                ?.mapNotNull { it?.code?.trim() }
+                ?.filterNot { it.isEmpty() } ?: emptyList()
 
-        val options =
-            optionRepository.getOptionsByCode(
-                config?.attendance?.status.orEmpty(),
-                optionsCode
-            )
+            val options =
+                optionRepository.getOptionsByCode(
+                    config?.attendance?.status.orEmpty(),
+                    optionsCode
+                )
 
-        options.mapNotNull {
-            val status = config?.attendance?.statusOptions?.find { status ->
-                status?.code == it.code()
+            val useAttendanceStatusFlow = config?.attendance?.attendanceStatus
+                .isEnabledAndConfigured()
+            val configuredOptions = options.mapNotNull {
+                val status = config?.attendance?.statusOptions?.find { status ->
+                    status?.code == it.code()
+                }
+                val isPresent = status?.key.equals(PRESENT_KEY, ignoreCase = true) ||
+                    status?.code.equals(PRESENT_KEY, ignoreCase = true)
+
+                if (status == null || useAttendanceStatusFlow && isPresent) {
+                    return@mapNotNull null
+                }
+
+                AttendanceButtonModel(
+                    key = status.key.orEmpty(),
+                    code = it.code(),
+                    name = it.displayName(),
+                    dataElement = config.attendance?.status.orEmpty(),
+                    icon = UiDefaults.dynamicIcons(status.icon.orEmpty()),
+                    iconName = status.icon.orEmpty(),
+                    color = getAttendanceStatusColor(
+                        status.key.orEmpty(),
+                        status.color.orEmpty()
+                    ),
+                    order = it.sortOrder() ?: -1,
+                    isAbsence = status.key.equals(ABSENT_KEY, ignoreCase = true),
+                )
             }
 
-            if (status == null) return@mapNotNull null
-
-            AttendanceButtonModel(
-                key = status.key.orEmpty(),
-                code = it.code(),
-                name = it.displayName(),
-                dataElement = config.attendance?.status.orEmpty(),
-                icon = UiDefaults.dynamicIcons(status.icon.orEmpty()),
-                iconName = status.icon.orEmpty(),
-                color = getAttendanceStatusColor(
-                    status.key.orEmpty(),
-                    status.color.orEmpty()
-                ),
-                order = it.sortOrder() ?: -1,
-            )
+            if (useAttendanceStatusFlow) {
+                listOf(
+                    AttendanceButtonModel(
+                        key = PRESENT_KEY,
+                        name = PRESENT_KEY.replaceFirstChar { it.uppercase() },
+                        dataElement = config?.attendance?.status.orEmpty(),
+                        iconName = PRESENT_ICON,
+                        color = getAttendanceStatusColor(PRESENT_KEY),
+                        order = -1,
+                    )
+                ) + configuredOptions
+            } else {
+                configuredOptions
+            }
         }
+
+    private companion object {
+        const val PRESENT_KEY = "present"
+        const val ABSENT_KEY = "absent"
+        const val PRESENT_ICON = "correct_blue_fill"
     }
 }

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -81,8 +81,22 @@ class FormRepositoryImpl @Inject constructor(
             it.event?.tei == tei?.uid()
         }
 
+        if (buttonModel.code == null) {
+            event?.event?.event?.let { eventRepository.deleteEvent(it) }
+            attendanceEvents.removeIf { it.event?.tei == tei?.uid() }
+
+            return attendanceButtonState.updateAndGet {
+                it.copy(attendanceEvents = attendanceEvents)
+            }
+        }
+
         if (event != null) {
-            val updatedEvent = event.event?.copy(value = buttonModel.code.orEmpty())
+            val currentEvent = event.event
+            val updatedEvent = currentEvent?.copy(
+                value = buttonModel.code.orEmpty(),
+                reasonDataElement = currentEvent.reasonDataElement,
+                reasonOfAbsence = currentEvent.reasonOfAbsence.takeIf { buttonModel.isAbsence },
+            )
             val eventWithDecorator = event.copy(
                 event = updatedEvent,
                 decorator = AttendanceButtonDecorator(
@@ -223,7 +237,8 @@ class FormRepositoryImpl @Inject constructor(
                     valueType = it.dataElement?.valueType() ?: ValueType.TEXT,
                     optionSet = options,
                     mandatory = it.compulsory == true,
-                    isAttendanceType = attendance?.status == it.dataElement?.uid()
+                    isAttendanceType = attendance?.status == it.dataElement?.uid(),
+                    isAttendanceReason = attendance?.absenceReason == it.dataElement?.uid(),
                 )
             }
 
@@ -303,14 +318,25 @@ class FormRepositoryImpl @Inject constructor(
 
     override suspend fun attendanceSummary(
         program: String,
+        totalLearners: Int,
         getSummaries: (List<BottomSheetModel>) -> Unit
     ) = withContext(Dispatchers.IO) {
         attendanceButtonStateFlow.collectLatest { current ->
             val options =
                 attendanceOptionRepository.getAttendanceStatusOptions(program)
 
+            val nonPresentCount = options
+                .filter { it.code != null }
+                .sumOf { option ->
+                    current.attendanceEvents.count { option.code == it.event?.value }
+                }
+
             val summaries = options.map { option ->
-                val count = current.attendanceEvents.count { option.code == it.event?.value }
+                val count = if (option.code == null) {
+                    (totalLearners - nonPresentCount).coerceAtLeast(0)
+                } else {
+                    current.attendanceEvents.count { option.code == it.event?.value }
+                }
 
                 BottomSheetModel(
                     icon = option.icon,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/AttendanceFieldVisibility.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/AttendanceFieldVisibility.kt
@@ -1,0 +1,19 @@
+package org.saudigitus.semis.core.form.ui
+
+import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
+import org.saudigitus.semis.core.form.data.model.FormFieldState
+
+internal fun visibleAttendanceFields(
+    key: String,
+    fields: List<FormFieldState>,
+    attendanceState: AttendanceButtonState,
+): List<FormFieldState> {
+    val attendanceEvent = attendanceState.attendanceEvents.find { it.event?.tei == key }
+    val isAbsent = attendanceState.buttons.any {
+        it.isAbsence && it.code == attendanceEvent?.event?.value
+    }
+
+    return fields.filter {
+        it.isAttendanceType || it.isAttendanceReason && isAbsent
+    }
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldItem.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldItem.kt
@@ -39,7 +39,11 @@ fun FormFieldItem(
     onAttendanceChange: (AttendanceButtonModel) -> Unit = {},
     onValueChange: (String) -> Unit
 ) {
-    val fieldData = fieldsData.find { it.tei == key }
+    val fieldData = if (field.isAttendanceReason) {
+        attendanceReasonFieldData(key, field, attendanceButtonState)
+    } else {
+        fieldsData.find { it.tei == key && it.dataElement == field.dataElementUid }
+    }
 
     Column(
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 5.dp),

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormScreen.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormScreen.kt
@@ -49,7 +49,13 @@ fun FormContent(
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    for (field in state.fields) {
+                    val visibleFields = if (type == FormType.ATTENDANCE) {
+                        visibleAttendanceFields(key, state.fields, state.attendanceButtonState)
+                    } else {
+                        state.fields.filter { it.rendered }
+                    }
+
+                    for (field in visibleFields) {
                         FormFieldItem(
                             key = key,
                             field = field,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormViewModel.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormViewModel.kt
@@ -138,6 +138,10 @@ class FormViewModel @Inject constructor(
         _uiState.update { it.copy(hasCachedData = false) }
     }
 
+    fun markAttendanceChanged() {
+        _uiState.update { it.copy(hasCachedData = true) }
+    }
+
     fun handleUiEvent(uiEvent: FormEvent) {
         viewModelScope.launch {
             when (uiEvent) {

--- a/semis/core/form/src/test/java/org/saudigitus/semis/core/form/ExampleUnitTest.kt
+++ b/semis/core/form/src/test/java/org/saudigitus/semis/core/form/ExampleUnitTest.kt
@@ -1,0 +1,17 @@
+package org.saudigitus.semis.core.form
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class ExampleUnitTest {
+    @Test
+    fun addition_isCorrect() {
+        assertEquals(4, 2 + 2)
+    }
+}

--- a/semis/core/form/src/test/java/org/saudigitus/semis/core/form/ui/AttendanceFieldVisibilityTest.kt
+++ b/semis/core/form/src/test/java/org/saudigitus/semis/core/form/ui/AttendanceFieldVisibilityTest.kt
@@ -1,0 +1,84 @@
+package org.saudigitus.semis.core.form.ui
+
+import org.hisp.dhis.android.core.common.ValueType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEvent
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+import org.saudigitus.semis.core.form.data.model.FormFieldState
+
+class AttendanceFieldVisibilityTest {
+
+    private val status = FormFieldState(
+        dataElementUid = "status",
+        label = "Current attendance status",
+        valueType = ValueType.TEXT,
+        isAttendanceType = true,
+    )
+    private val reason = FormFieldState(
+        dataElementUid = "reason",
+        label = "Reason of absence",
+        valueType = ValueType.TEXT,
+        isAttendanceReason = true,
+    )
+    private val absentDays = FormFieldState(
+        dataElementUid = "days",
+        label = "Absent days",
+        valueType = ValueType.INTEGER,
+    )
+    private val buttons = listOf(
+        AttendanceButtonModel(key = "present"),
+        AttendanceButtonModel(key = "absent", code = "ABS", isAbsence = true),
+        AttendanceButtonModel(key = "late", code = "LATE"),
+    )
+
+    @Test
+    fun `shows only attendance status when learner is present`() {
+        val visible = visibleAttendanceFields(
+            key = "learner",
+            fields = listOf(status, reason, absentDays),
+            attendanceState = AttendanceButtonState(buttons = buttons),
+        )
+
+        assertEquals(listOf(status), visible)
+    }
+
+    @Test
+    fun `shows absence reason only for absence status`() {
+        val visible = visibleAttendanceFields(
+            key = "learner",
+            fields = listOf(status, reason, absentDays),
+            attendanceState = attendanceState("ABS"),
+        )
+
+        assertEquals(listOf(status, reason), visible)
+    }
+
+    @Test
+    fun `does not show absence reason for another non-present status`() {
+        val visible = visibleAttendanceFields(
+            key = "learner",
+            fields = listOf(status, reason, absentDays),
+            attendanceState = attendanceState("LATE"),
+        )
+
+        assertEquals(listOf(status), visible)
+    }
+
+    private fun attendanceState(value: String) = AttendanceButtonState(
+        buttons = buttons,
+        attendanceEvents = listOf(
+            AttendanceEventWithDecorator(
+                event = AttendanceEvent(
+                    tei = "learner",
+                    enrollment = "enrollment",
+                    dataElement = "status",
+                    value = value,
+                    date = "2026-08-13",
+                ),
+            )
+        ),
+    )
+}


### PR DESCRIPTION
* Refactor attendance recording to support a "Complete Attendance" workflow that calculates and saves summaries (total learners, absences, etc.) to a program stage.
* Introduce `AttendanceFieldVisibility` logic to dynamically show or hide absence reason fields based on the selected attendance status.
* Add support for a default "Present" state in `AttendanceButton` and `AttendanceOptionRepository`, including logic to delete events when returning to a default state.
* Update `AttendanceViewModel` to handle the lifecycle of creating and completing global attendance status events.
* Extend `AttendanceStatus` configuration model to include mappings for total absences and total records data elements.
* Implement `AttendanceSummaryCounts` to calculate status-specific counts for reporting.
* Enhance `EventRepository` with `deleteEvent` functionality and fix secondary data value persistence logic.
* Update UI components and strings to distinguish between "Take Attendance" and "Complete Attendance" actions.
* Add unit tests for attendance field visibility, summary count calculations, and configuration parsing.