### PR TITLE
feat: implement attendance form reset and completion validation

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.CardDefaults
@@ -31,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.Font
@@ -63,6 +65,8 @@ import org.saudigitus.semis.core.designsystem.components.bottomsheet.model.Botto
 import org.saudigitus.semis.core.designsystem.components.summary.SummaryDetails
 import org.saudigitus.semis.core.designsystem.templates.TopAppBarScaffold
 import org.saudigitus.semis.core.designsystem.theme.dark_warning
+import org.saudigitus.semis.core.designsystem.theme.light_error
+import org.saudigitus.semis.core.designsystem.theme.light_success
 import org.saudigitus.semis.core.designsystem.utils.UiDefaults
 import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
 import org.saudigitus.semis.core.designsystem.utils.mapper.searchTeiMapper
@@ -77,6 +81,7 @@ fun AttendanceScreen(
     state: AttendanceUiState,
     formState: FormUiState,
     snackbarHostState: SnackbarHostState,
+    snackbarIsError: Boolean,
     teiCardMapper: TEICardMapper,
     onFormEvent: (FormEvent) -> Unit,
     onEvent: (AttendanceUiEvent) -> Unit,
@@ -149,44 +154,76 @@ fun AttendanceScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 hostState = snackbarHostState,
+                containerColor = if (snackbarIsError) light_error else light_success,
+                painter = painterResource(
+                    if (snackbarIsError) {
+                        R.drawable.ic_outline_error_36
+                    } else {
+                        R.drawable.success_icon
+                    }
+                ),
             )
         },
         floatingActionButton = {
-            ExtendedFloatingActionButton(
-                text = {
-                    Text(
-                        text = if (state.buttonStep == ButtonStep.NONE) {
-                            stringResource(R.string.take_attendance)
-                        } else if (state.allowAttendanceStatus) {
-                            stringResource(R.string.complete_attendance)
-                        } else {
-                            stringResource(R.string.save)
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (state.buttonStep != ButtonStep.NONE) {
+                    ExtendedFloatingActionButton(
+                        text = {
+                            Text(
+                                text = stringResource(R.string.reset_attendance_form),
+                                style = LocalTextStyle.current.copy(
+                                    fontFamily = FontFamily(Font(R.font.rubik_medium)),
+                                ),
+                            )
                         },
-                        color = colorPrimary,
-                        style = LocalTextStyle.current.copy(
-                            fontFamily = FontFamily(Font(R.font.rubik_medium)),
-                        ),
-                    )
-                },
-                icon = {
-                    Icon(
-                        imageVector = if (state.buttonStep == ButtonStep.NONE) {
-                            Icons.Default.Edit
-                        } else {
-                            Icons.Default.Save
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = null,
+                            )
                         },
-                        contentDescription = null,
-                        tint = colorPrimary,
+                        onClick = { onEvent(AttendanceUiEvent.ResetForm) },
                     )
-                },
-                onClick = {
-                    if (state.buttonStep == ButtonStep.NONE && state.canTakeAttendance) {
-                        onEvent(AttendanceUiEvent.OnEditClicked)
-                    } else if (state.canTakeAttendance) {
-                        onEvent(AttendanceUiEvent.ShowBottomSheet(BottomSheetType.SUMMARY))
+                }
+                ExtendedFloatingActionButton(
+                    text = {
+                        Text(
+                            text = if (state.buttonStep == ButtonStep.NONE) {
+                                stringResource(R.string.take_attendance)
+                            } else if (state.allowAttendanceStatus) {
+                                stringResource(R.string.complete_attendance)
+                            } else {
+                                stringResource(R.string.save)
+                            },
+                            color = colorPrimary,
+                            style = LocalTextStyle.current.copy(
+                                fontFamily = FontFamily(Font(R.font.rubik_medium)),
+                            ),
+                        )
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = if (state.buttonStep == ButtonStep.NONE) {
+                                Icons.Default.Edit
+                            } else {
+                                Icons.Default.Save
+                            },
+                            contentDescription = null,
+                            tint = colorPrimary,
+                        )
+                    },
+                    onClick = {
+                        if (state.buttonStep == ButtonStep.NONE && state.canTakeAttendance) {
+                            onEvent(AttendanceUiEvent.OnEditClicked)
+                        } else if (state.canTakeAttendance) {
+                            onEvent(AttendanceUiEvent.ShowBottomSheet(BottomSheetType.SUMMARY))
+                        }
                     }
-                },
-            )
+                )
+            }
         }
     ) {
         SummaryDetails(

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUi.kt
@@ -6,7 +6,9 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -26,6 +28,7 @@ fun AttendanceUi(
     syncData: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+    var snackbarIsError by remember { mutableStateOf(false) }
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val formState by formViewModel.uiState.collectAsStateWithLifecycle()
@@ -33,6 +36,7 @@ fun AttendanceUi(
     LaunchedEffect(Unit) {
         viewModel.snackbarEvent.collectLatest { message ->
             if (message != null) {
+                snackbarIsError = false
                 formViewModel.resetCacheStatus()
                 snackbarHostState.showSnackbar(
                     message = message,
@@ -50,6 +54,7 @@ fun AttendanceUi(
 
     LaunchedEffect(Unit) {
         viewModel.errorEvent.collectLatest { message ->
+            snackbarIsError = true
             snackbarHostState.showSnackbar(
                 message = message,
                 duration = SnackbarDuration.Long,
@@ -92,6 +97,7 @@ fun AttendanceUi(
         state = state,
         formState = formState,
         snackbarHostState = snackbarHostState,
+        snackbarIsError = snackbarIsError,
         teiCardMapper = teiCardMapper,
         onFormEvent = formViewModel::handleUiEvent,
         onEvent = {
@@ -103,6 +109,10 @@ fun AttendanceUi(
                 is AttendanceUiEvent.OnSyncClicked -> syncData()
                 is AttendanceUiEvent.OnAttendanceClick -> {
                     formViewModel.markAttendanceChanged()
+                    viewModel.handleUiEvent(it)
+                }
+                AttendanceUiEvent.ResetForm -> {
+                    formViewModel.resetCacheStatus()
                     viewModel.handleUiEvent(it)
                 }
                 else -> viewModel.handleUiEvent(it)

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
@@ -10,6 +10,7 @@ sealed class AttendanceUiEvent {
     data class OnDateSelect(val date: String) : AttendanceUiEvent()
     data object OnSyncClicked : AttendanceUiEvent()
     data object OnEditClicked : AttendanceUiEvent()
+    data object ResetForm : AttendanceUiEvent()
     data object BulkOverrideAttendance : AttendanceUiEvent()
     data class BottomSheetAction(val action: BottomSheetConfirmAction) : AttendanceUiEvent()
     data class DismissBottomSheet(val type: BottomSheetType): AttendanceUiEvent()

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -18,6 +18,7 @@ import org.hisp.dhis.android.core.maintenance.D2Error
 import org.saudigitus.semis.attendance.R
 import org.saudigitus.semis.attendance.ui.model.BottomSheetConfirmAction
 import org.saudigitus.semis.attendance.ui.model.BottomSheetType
+import org.saudigitus.semis.attendance.ui.model.missingLearnerAttendanceCount
 import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.data.model.app_config.Attendance
@@ -230,8 +231,27 @@ class AttendanceViewModel @Inject constructor(
         }
     }
 
-    private fun save() {
+    private fun save(): Boolean {
+        val current = uiState.value
+        if (!current.allowAttendanceStatus) {
+            val missingLearners = missingLearnerAttendanceCount(
+                learnerUids = studentsIds,
+                attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents,
+            )
+            if (missingLearners > 0) {
+                viewModelScope.launch {
+                    _errorEvent.emit(
+                        resourceManager.getString(
+                            R.string.attendance_status_incomplete,
+                            missingLearners,
+                        )
+                    )
+                }
+                return false
+            }
+        }
         saveAttendanceEvents()
+        return true
     }
 
     private fun startAttendance() {
@@ -340,6 +360,10 @@ class AttendanceViewModel @Inject constructor(
                 startAttendance()
             }
 
+            AttendanceUiEvent.ResetForm -> {
+                resetForm()
+            }
+
             is AttendanceUiEvent.OnAttendanceClick -> {
                 if (!uiState.value.allowAttendanceStatus) {
                     viewModelScope.launch {
@@ -402,9 +426,10 @@ class AttendanceViewModel @Inject constructor(
                         it.copy(displayBulk = false)
                     }
                 } else {
-                    save()
-                    _uiState.update {
-                        it.copy(displayDialog = false)
+                    if (save()) {
+                        _uiState.update {
+                            it.copy(displayDialog = false)
+                        }
                     }
                 }
             }
@@ -419,5 +444,17 @@ class AttendanceViewModel @Inject constructor(
 
     fun resetForm() {
         formRepository.reset()
+        _hasCachedData.value = false
+        cachedButtonModel = null
+        _uiState.update {
+            it.copy(
+                displayBulk = false,
+                displayDialog = false,
+                overrideBulk = false,
+            )
+        }
+        viewModelScope.launch {
+            _snackbarEvent.emit(resourceManager.getString(R.string.attendance_form_reset))
+        }
     }
 }

--- a/semis/attendance/src/main/res/values/strings.xml
+++ b/semis/attendance/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="attendance">Attendance</string>
     <string name="attendance_summary">Attendance Summary</string>
     <string name="attendance_not_saved">You have unsaved attendance changes. If you go back now, your data will be discarded.</string>
+    <string name="attendance_form_reset">Attendance form reset</string>
+    <string name="attendance_status_incomplete">Select an attendance status for every learner before saving. %1$d selections remaining.</string>
 </resources>

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="update">Update</string>
     <string name="take_attendance">Take Attendance</string>
     <string name="complete_attendance">Complete Attendance</string>
+    <string name="reset_attendance_form">Reset attendance</string>
     <string name="app_not_properly_config">App not configured properly. Please contact System Administrator</string>
     <string name="attendance_saved">Attendance saved successfully</string>
     <string name="not_saved">Not saved</string>

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -50,6 +50,7 @@ class FormRepositoryImpl @Inject constructor(
 ) : FormRepository {
 
     private val attendanceButtonState = MutableStateFlow(AttendanceButtonState())
+    private var loadedAttendanceButtonState = AttendanceButtonState()
 
     override val attendanceButtonStateFlow: StateFlow<AttendanceButtonState> = attendanceButtonState
 
@@ -198,7 +199,9 @@ class FormRepositoryImpl @Inject constructor(
                 .orEmpty()
         )
 
-        attendanceButtonState.value = buttonState(program, attendanceEvents)
+        val loadedState = buttonState(program, attendanceEvents)
+        loadedAttendanceButtonState = loadedState
+        attendanceButtonState.value = loadedState
 
         return@withContext attendanceButtonStateFlow.value
     }
@@ -359,7 +362,10 @@ class FormRepositoryImpl @Inject constructor(
     }
 
     override fun reset() {
-        attendanceButtonState.value = AttendanceButtonState()
+        attendanceButtonState.value = resetAttendanceFormState(
+            current = attendanceButtonState.value,
+            loaded = loadedAttendanceButtonState,
+        )
     }
 
     override suspend fun saveAttendance(


### PR DESCRIPTION
* Add a "Reset attendance" floating action button to `AttendanceScreen` that appears during the attendance-taking process.
* Implement validation in `AttendanceViewModel` to prevent saving when learner attendance records are incomplete (if global attendance status is not used).
* Enhance the snackbar notification system to support distinct success and error states with specific colors and icons.
* Update `FormRepositoryImpl` to track the initial loaded state, enabling the reset functionality to revert the form to its original values.
* Introduce `AttendanceUiEvent.ResetForm` to handle the form reset lifecycle, including clearing cached data and displaying a confirmation message.
* Add UI strings for attendance form reset actions and incomplete status warnings.