### PR TITLE
refactor: attendance summary calculation and update status configuration

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusSummaryValues.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusSummaryValues.kt
@@ -1,0 +1,46 @@
+package org.saudigitus.semis.attendance.ui.model
+
+import org.saudigitus.semis.core.data.model.app_config.StatusOption
+
+internal const val PRESENT_STATUS_KEY = "present"
+
+/**
+ * The configured status standing for a recorded presence, which carries no attendance
+ * value of its own and is therefore counted as whatever the other statuses leave over.
+ */
+internal fun StatusOption.isPresent() =
+    key.equals(PRESENT_STATUS_KEY, ignoreCase = true) ||
+        code.equals(PRESENT_STATUS_KEY, ignoreCase = true)
+
+/**
+ * Maps the attendance counts of a day onto the data elements of the attendance status
+ * event: the learner total, then one summary per configured status.
+ *
+ * Statuses are configuration driven, so the counts cannot be flattened into a single
+ * absence total. Each option instead declares the data element holding its own summary
+ * through [StatusOption.totalSummary]; an option configured without one has nowhere to be
+ * stored and is skipped rather than written somewhere else.
+ */
+internal fun attendanceStatusSummaryValues(
+    statusOptions: List<StatusOption>,
+    totalRecordsDataElement: String,
+    counts: AttendanceSummaryCounts,
+): List<Pair<String, String>> {
+    val values = linkedMapOf<String, String>()
+
+    values[totalRecordsDataElement] = counts.totalLearners.toString()
+
+    statusOptions.forEach { status ->
+        val summaryDataElement = status.totalSummary?.takeIf { it.isNotBlank() }
+            ?: return@forEach
+        val count = if (status.isPresent()) {
+            counts.presentLearners
+        } else {
+            counts.statusCounts[status.code] ?: 0
+        }
+
+        values[summaryDataElement] = count.toString()
+    }
+
+    return values.map { it.key to it.value }
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -3,13 +3,13 @@ package org.saudigitus.semis.attendance.ui.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.D2
-import org.hisp.dhis.android.core.dataelement.DataElement
 import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
+import org.saudigitus.semis.attendance.ui.model.attendanceStatusSummaryValues
 import org.saudigitus.semis.attendance.ui.model.attendanceSummaryCounts
-import org.saudigitus.semis.core.data.model.app_config.StatusOption
+import org.saudigitus.semis.attendance.ui.model.isPresent
 import org.saudigitus.semis.core.data.model.app_config.isEnabledAndConfigured
 import org.saudigitus.semis.core.data.repository.AppConfigRepository
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
@@ -89,7 +89,6 @@ class AttendanceRepositoryImpl(
 
         val summary = summaryValues(
             program = program,
-            programStage = attendanceStatus.programStage.orEmpty(),
             totalLearners = totalLearners,
             attendanceEvents = attendanceEvents,
         )
@@ -161,7 +160,6 @@ class AttendanceRepositoryImpl(
 
     private suspend fun summaryValues(
         program: String,
-        programStage: String,
         totalLearners: Int,
         attendanceEvents: List<AttendanceEventWithDecorator>,
     ): List<Pair<String, String>> {
@@ -169,92 +167,25 @@ class AttendanceRepositoryImpl(
         val configuredStatuses = attendance?.statusOptions
             ?.filterNotNull()
             .orEmpty()
-        val nonPresentStatuses = configuredStatuses
-            .filterNot { it.isPresent() }
-            .distinctBy { it.code }
         val summaryCounts = attendanceSummaryCounts(
             totalLearners = totalLearners,
-            configuredStatusCodes = nonPresentStatuses.mapNotNull { it.code },
+            configuredStatusCodes = configuredStatuses
+                .filterNot { it.isPresent() }
+                .mapNotNull { it.code },
             attendanceValues = attendanceEvents.mapNotNull { it.event?.value },
         )
-        val stageDataElements = programStageDataElements(programStage)
-        val values = linkedMapOf<String, String>()
         val attendanceStatusConfig = attendance?.attendanceStatus
             ?: error("Attendance status configuration is missing")
-        val totalAbsencesDataElement = attendanceStatusConfig.totalAbsences
-            ?.takeIf { it.isNotBlank() }
-            ?: error("Attendance status total absences data element is missing")
         val totalRecordsDataElement = attendanceStatusConfig.totalRecords
             ?.takeIf { it.isNotBlank() }
             ?: error("Attendance status total records data element is missing")
 
-        values[totalAbsencesDataElement] = summaryCounts.totalAbsences.toString()
-        values[totalRecordsDataElement] = summaryCounts.totalLearners.toString()
-
-        nonPresentStatuses.forEach { status ->
-            val dataElement = resolveDataElement(
-                stageDataElements,
-                listOfNotNull(status.configKey, status.key, status.code),
-            )
-            dataElement?.let {
-                values[it.uid()] = (summaryCounts.statusCounts[status.code] ?: 0).toString()
-            }
-        }
-
-        val presentStatus = configuredStatuses.firstOrNull { it.isPresent() }
-        resolveDataElement(
-            stageDataElements,
-            listOfNotNull(
-                presentStatus?.configKey,
-                presentStatus?.key,
-                presentStatus?.code,
-                PRESENT_KEY,
-            ),
-        )?.let {
-            values[it.uid()] = summaryCounts.presentLearners.toString()
-        }
-
-        return values.map { it.key to it.value }
+        return attendanceStatusSummaryValues(
+            statusOptions = configuredStatuses,
+            totalRecordsDataElement = totalRecordsDataElement,
+            counts = summaryCounts,
+        )
     }
-
-    private fun programStageDataElements(programStage: String): List<DataElement> =
-        d2.programModule().programStageDataElements()
-            .byProgramStage().eq(programStage)
-            .blockingGet()
-            .mapNotNull { it.dataElement()?.uid() }
-            .distinct()
-            .mapNotNull { d2.dataElementModule().dataElements().uid(it).blockingGet() }
-
-    private fun resolveDataElement(
-        dataElements: List<DataElement>,
-        identifiers: List<String>,
-        minimumPartialLength: Int = 1,
-    ): DataElement? {
-        val normalizedIdentifiers = identifiers
-            .map(::normalize)
-            .filter { it.isNotEmpty() }
-
-        return dataElements.firstOrNull { dataElement ->
-            dataElement.identifiers().any { it in normalizedIdentifiers }
-        } ?: dataElements.firstOrNull { dataElement ->
-            dataElement.identifiers().any { metadataIdentifier ->
-                normalizedIdentifiers
-                    .filter { it.length >= minimumPartialLength }
-                    .any { identifier ->
-                        metadataIdentifier.contains(identifier) || identifier.contains(
-                            metadataIdentifier
-                        )
-                    }
-            }
-        }
-    }
-
-    private fun DataElement.identifiers() = listOfNotNull(
-        uid(),
-        code(),
-        displayName(),
-        displayFormName(),
-    ).map(::normalize)
 
     private fun Event.matches(contextValues: List<Pair<String, String>>) =
         contextValues.all { (dataElement, value) ->
@@ -270,14 +201,6 @@ class AttendanceRepositoryImpl(
             dataElement to value
         }
 
-    private fun StatusOption.isPresent() =
-        key.equals(PRESENT_KEY, ignoreCase = true) ||
-            code.equals(PRESENT_KEY, ignoreCase = true)
-
-    private fun normalize(value: String) = value
-        .lowercase()
-        .filter(Char::isLetterOrDigit)
-
     private suspend fun attendanceStatusConfig(program: String) =
         appConfigRepository.getAppConfig(program)
             ?.attendance
@@ -290,9 +213,4 @@ class AttendanceRepositoryImpl(
             .one()
             .blockingGet()
             ?.uid()
-
-    private companion object {
-        const val PRESENT_KEY = "present"
-
-    }
 }

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusSummaryValuesTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusSummaryValuesTest.kt
@@ -1,0 +1,93 @@
+package org.saudigitus.semis.attendance.ui.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.data.model.app_config.StatusOption
+
+class AttendanceStatusSummaryValuesTest {
+
+    private fun statusOption(
+        code: String?,
+        key: String?,
+        totalSummary: String?,
+    ) = StatusOption(
+        code = code,
+        color = null,
+        configKey = null,
+        icon = null,
+        key = key,
+        totalSummary = totalSummary,
+    )
+
+    private val present = statusOption("PRESENT", "present", "de_present")
+    private val absent = statusOption("ABSENT", "absent", "de_absent")
+    private val late = statusOption("LATE", "late", "de_late")
+
+    private fun counts(
+        totalLearners: Int,
+        attendanceValues: List<String>,
+        codes: List<String> = listOf("ABSENT", "LATE"),
+    ) = attendanceSummaryCounts(
+        totalLearners = totalLearners,
+        configuredStatusCodes = codes,
+        attendanceValues = attendanceValues,
+    )
+
+    @Test
+    fun `each configured status is written to the data element it declares`() {
+        val values = attendanceStatusSummaryValues(
+            statusOptions = listOf(present, absent, late),
+            totalRecordsDataElement = "de_total",
+            counts = counts(10, listOf("ABSENT", "ABSENT", "LATE")),
+        ).toMap()
+
+        assertEquals("10", values["de_total"])
+        assertEquals("7", values["de_present"])
+        assertEquals("2", values["de_absent"])
+        assertEquals("1", values["de_late"])
+    }
+
+    @Test
+    fun `a status configured without a summary data element is skipped`() {
+        val values = attendanceStatusSummaryValues(
+            statusOptions = listOf(present, absent, statusOption("LATE", "late", null)),
+            totalRecordsDataElement = "de_total",
+            counts = counts(5, listOf("ABSENT", "LATE")),
+        ).toMap()
+
+        assertEquals(setOf("de_total", "de_present", "de_absent"), values.keys)
+        assertEquals("3", values["de_present"])
+    }
+
+    @Test
+    fun `statuses added by configuration are collected without touching the mapping`() {
+        val excused = statusOption("EXCUSED", "excused", "de_excused")
+
+        val values = attendanceStatusSummaryValues(
+            statusOptions = listOf(present, absent, late, excused),
+            totalRecordsDataElement = "de_total",
+            counts = counts(
+                totalLearners = 8,
+                attendanceValues = listOf("ABSENT", "EXCUSED", "EXCUSED"),
+                codes = listOf("ABSENT", "LATE", "EXCUSED"),
+            ),
+        ).toMap()
+
+        assertEquals("2", values["de_excused"])
+        assertEquals("1", values["de_absent"])
+        assertEquals("0", values["de_late"])
+        assertEquals("5", values["de_present"])
+    }
+
+    @Test
+    fun `the present status is counted as the learners the other statuses leave over`() {
+        val values = attendanceStatusSummaryValues(
+            statusOptions = listOf(present, absent),
+            totalRecordsDataElement = "de_total",
+            counts = counts(4, emptyList()),
+        ).toMap()
+
+        assertEquals("4", values["de_present"])
+        assertEquals("0", values["de_absent"])
+    }
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/AttendanceStatus.kt
@@ -10,9 +10,7 @@ data class AttendanceStatus(
     val allowAttendanceStatus: Boolean? = null,
     val program: String? = null,
     val programStage: String? = null,
-    @JsonNames("totalAbsencesDataElement")
-    val totalAbsences: String? = null,
-    @JsonNames("totalRecordsDataElement")
+    @JsonNames("totalRecords")
     val totalRecords: String? = null,
 )
 
@@ -22,6 +20,5 @@ fun AttendanceStatus?.isEnabledAndConfigured(): Boolean {
     return config.allowAttendanceStatus == true &&
         !config.program.isNullOrBlank() &&
         !config.programStage.isNullOrBlank() &&
-        !config.totalAbsences.isNullOrBlank() &&
         !config.totalRecords.isNullOrBlank()
 }

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/StatusOption.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/app_config/StatusOption.kt
@@ -15,5 +15,7 @@ data class StatusOption(
     @SerialName("icon")
     val icon: String?,
     @SerialName("key")
-    val key: String?
+    val key: String?,
+    @SerialName("totalSummary")
+    val totalSummary: String?,
 )


### PR DESCRIPTION
* Remove `totalAbsences` field from `AttendanceStatus` configuration and repository summary calculations.
* Add `totalSummary` property to `StatusOption` to support status-specific summary mapping.
* Extract summary value mapping logic from `AttendanceRepositoryImpl` to a new `attendanceStatusSummaryValues` helper.
* Simplify `AttendanceRepositoryImpl` by removing manual data element resolution and string normalization logic.
* Update `AttendanceStatus` model to use `@JsonNames("totalRecords")` and refine configuration validation requirements.
* Update `summaryCounts` logic to filter non-present statuses more efficiently using `StatusOption` extensions.
