### PR TITLE
feat: implement attendance reset and completion status tracking

### DIFF
--- a/semis/attendance/build.gradle.kts
+++ b/semis/attendance/build.gradle.kts
@@ -98,6 +98,10 @@ dependencies {
     coreLibraryDesugaring(libs.desugar)
 
     testImplementation(libs.test.junit)
+    testImplementation(libs.test.mockitoCore)
+    testImplementation(libs.test.mockitoInline)
+    testImplementation(libs.test.mockitoKotlin)
+    testImplementation(libs.test.kotlinCoroutines)
     androidTestImplementation(libs.test.junit.ext)
     androidTestImplementation(libs.test.espresso)
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.saudigitus.semis.attendance.ui.components.AttendanceBulkBar
+import org.saudigitus.semis.attendance.ui.components.AttendanceCompletionNotice
 import org.saudigitus.semis.attendance.ui.components.AttendanceHeader
 import org.saudigitus.semis.attendance.ui.components.AttendanceSaveBar
 import org.saudigitus.semis.attendance.ui.components.AttendanceStudentCard
@@ -62,6 +63,14 @@ fun AttendanceScreen(
             onConfirm = {
                 onEvent(AttendanceUiEvent.BottomSheetAction(BottomSheetConfirmAction.PERFORM_SAVE))
             }
+        )
+    }
+
+    if (state.displayResetDialog) {
+        AlertDialog(
+            message = stringResource(id = AttendanceRes.string.attendance_reset_warning),
+            onConfirm = { onEvent(AttendanceUiEvent.ConfirmResetForm) },
+            onDismissRequest = { onEvent(AttendanceUiEvent.DismissResetDialog) },
         )
     }
 
@@ -189,6 +198,13 @@ fun AttendanceScreen(
                         text = stringResource(AttendanceRes.string.attendance_not_recorded),
                         imageVector = Icons.Default.EventBusy,
                         tone = dark_warning,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+
+                state.allowAttendanceStatus && state.attendanceStatus != null -> {
+                    AttendanceCompletionNotice(
+                        completed = state.isAttendanceCompleted,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     )
                 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiEvent.kt
@@ -11,6 +11,8 @@ sealed class AttendanceUiEvent {
     data object OnSyncClicked : AttendanceUiEvent()
     data object OnEditClicked : AttendanceUiEvent()
     data object ResetForm : AttendanceUiEvent()
+    data object ConfirmResetForm : AttendanceUiEvent()
+    data object DismissResetDialog : AttendanceUiEvent()
     data object BulkOverrideAttendance : AttendanceUiEvent()
     data class BottomSheetAction(val action: BottomSheetConfirmAction) : AttendanceUiEvent()
     data class DismissBottomSheet(val type: BottomSheetType): AttendanceUiEvent()

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceUiState.kt
@@ -1,6 +1,7 @@
 package org.saudigitus.semis.attendance.ui
 
 import androidx.compose.runtime.Immutable
+import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
 import org.saudigitus.semis.core.data.model.SearchTeiModel
 import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceButtonModel
@@ -16,6 +17,7 @@ data class AttendanceUiState(
     val displayBulk: Boolean = false,
     val displayDialog: Boolean = false,
     val overrideBulk: Boolean = false,
+    val displayResetDialog: Boolean = false,
     val toolbarHeaders: ToolbarHeaders = ToolbarHeaders(""),
     val dateValidator: (Long) -> Boolean = { _ -> true },
     val program: String = "",
@@ -35,4 +37,17 @@ data class AttendanceUiState(
     val bottomSheetState: BottomSheetState.HasItemsState = BottomSheetState.HasItemsState(),
     val genericsBottomSheetState: BottomSheetState.GenericsState<AttendanceButtonModel> = BottomSheetState.GenericsState(),
     val errorMessage: String? = null
-)
+) {
+    /** Whether the attendance status event of the day has been completed. */
+    val isAttendanceCompleted: Boolean
+        get() = attendanceStatus?.status == EventStatus.COMPLETED
+
+    /**
+     * Whether the day carries an attendance status event that is still open, which the
+     * screen reports as an incomplete attendance.
+     */
+    val isAttendanceIncomplete: Boolean
+        get() = allowAttendanceStatus &&
+            attendanceStatus != null &&
+            attendanceStatus.status != EventStatus.COMPLETED
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -380,7 +380,15 @@ class AttendanceViewModel @Inject constructor(
             }
 
             AttendanceUiEvent.ResetForm -> {
-                resetForm()
+                _uiState.update { it.copy(displayResetDialog = true) }
+            }
+
+            AttendanceUiEvent.DismissResetDialog -> {
+                _uiState.update { it.copy(displayResetDialog = false) }
+            }
+
+            AttendanceUiEvent.ConfirmResetForm -> {
+                discardAttendance()
             }
 
             is AttendanceUiEvent.OnAttendanceClick -> {
@@ -457,6 +465,46 @@ class AttendanceViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Clears the attendance recorded for the selected date.
+     *
+     * The attendance status event is kept and only has its counters rewritten: when the
+     * status flow is on, a learner without a record counts as present, so deleting the
+     * coded records is what resets the day. Without the status flow every record of the
+     * date is deleted, since each learner carries one.
+     */
+    private fun discardAttendance() {
+        viewModelScope.launch {
+            val current = uiState.value
+
+            runCatching {
+                formRepository.deleteAttendance(absencesOnly = current.allowAttendanceStatus)
+
+                if (current.allowAttendanceStatus) {
+                    attendanceRepository.updateAttendanceStatusSummary(
+                        orgUnit = current.formBuilderState.orgUnit,
+                        program = current.program,
+                        date = selectedDate,
+                        filterDetailsState = current.attendanceSummaryState.filterDetailsState,
+                        totalLearners = studentsIds.size,
+                        attendanceEvents = formRepository.attendanceButtonStateFlow
+                            .value
+                            .attendanceEvents,
+                    )
+                }
+            }.onSuccess {
+                resetForm()
+                loadAttendanceEventsByDate(selectedDate)
+                attendanceSummary()
+                _syncEvent.emit(Unit)
+            }.onFailure { error ->
+                val message = friendlyErrorMessage(error)
+                _uiState.update { it.copy(displayResetDialog = false, errorMessage = message) }
+                _errorEvent.emit(message)
+            }
+        }
+    }
+
     fun disableEditing() {
         formRepository.allowFormEdition(false)
     }
@@ -470,6 +518,7 @@ class AttendanceViewModel @Inject constructor(
                 displayBulk = false,
                 displayDialog = false,
                 overrideBulk = false,
+                displayResetDialog = false,
             )
         }
         viewModelScope.launch {

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceCompletionNotice.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceCompletionNotice.kt
@@ -1,0 +1,36 @@
+package org.saudigitus.semis.attendance.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.PendingActions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import org.saudigitus.semis.attendance.R
+import org.saudigitus.semis.core.designsystem.components.notice.InlineNotice
+import org.saudigitus.semis.core.designsystem.theme.dark_warning
+import org.saudigitus.semis.core.designsystem.theme.light_success
+import org.saudigitus.semis.core.designsystem.theme.contentTone
+
+/**
+ * States whether the attendance status event of the day has been completed, so the user
+ * can tell a finished day from one that is still open.
+ */
+@Composable
+internal fun AttendanceCompletionNotice(
+    completed: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    InlineNotice(
+        modifier = modifier,
+        text = stringResource(
+            if (completed) R.string.attendance_completed else R.string.attendance_incomplete,
+        ),
+        imageVector = if (completed) {
+            Icons.Default.CheckCircle
+        } else {
+            Icons.Default.PendingActions
+        },
+        tone = if (completed) light_success.contentTone() else dark_warning,
+    )
+}

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
@@ -22,6 +22,19 @@ interface AttendanceRepository {
         attendanceEvents: List<AttendanceEventWithDecorator>,
     ): AttendanceStatus?
 
+    /**
+     * Rewrites the status counters of the day without closing the request, so a reset or
+     * an edit leaves the attendance status event consistent with what is recorded.
+     */
+    suspend fun updateAttendanceStatusSummary(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ): AttendanceStatus?
+
     suspend fun getAttendanceStatus(
         orgUnit: String,
         program: String,

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -87,6 +87,53 @@ class AttendanceRepositoryImpl(
             filterDetailsState,
         ) ?: return@withContext null
 
+        writeStatusValues(
+            attendanceStatus = attendanceStatus,
+            program = program,
+            filterDetailsState = filterDetailsState,
+            totalLearners = totalLearners,
+            attendanceEvents = attendanceEvents,
+        )
+
+        d2.eventModule().events().uid(attendanceStatus.event)
+            .setStatus(EventStatus.COMPLETED)
+
+        attendanceStatus.copy(status = EventStatus.COMPLETED)
+    }
+
+    override suspend fun updateAttendanceStatusSummary(
+        orgUnit: String,
+        program: String,
+        date: String,
+        filterDetailsState: FilterDetailsState,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ): AttendanceStatus? = withContext(Dispatchers.IO) {
+        val attendanceStatus = getAttendanceStatus(
+            orgUnit,
+            program,
+            date,
+            filterDetailsState,
+        ) ?: return@withContext null
+
+        writeStatusValues(
+            attendanceStatus = attendanceStatus,
+            program = program,
+            filterDetailsState = filterDetailsState,
+            totalLearners = totalLearners,
+            attendanceEvents = attendanceEvents,
+        )
+
+        attendanceStatus
+    }
+
+    private suspend fun writeStatusValues(
+        attendanceStatus: AttendanceStatus,
+        program: String,
+        filterDetailsState: FilterDetailsState,
+        totalLearners: Int,
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+    ) {
         val summary = summaryValues(
             program = program,
             totalLearners = totalLearners,
@@ -100,11 +147,6 @@ class AttendanceRepositoryImpl(
                     .value(attendanceStatus.event, dataElement)
                     .blockingSet(value)
             }
-
-        d2.eventModule().events().uid(attendanceStatus.event)
-            .setStatus(EventStatus.COMPLETED)
-
-        attendanceStatus.copy(status = EventStatus.COMPLETED)
     }
 
     override suspend fun getAttendanceStatus(

--- a/semis/attendance/src/main/res/values/strings.xml
+++ b/semis/attendance/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="attendance_unsynced_count">%1$d unsynced</string>
     <string name="attendance_all_recorded">All students recorded</string>
     <string name="attendance_not_recorded">No attendance has been recorded for this day yet.</string>
+    <string name="attendance_reset_warning">Resetting deletes the attendance already recorded for this day. This cannot be undone.</string>
+    <string name="attendance_completed">Attendance completed for this day</string>
+    <string name="attendance_incomplete">Incomplete attendance</string>
     <string name="select_attendance_date">Select attendance date</string>
     <string name="reset_attendance">Reset attendance</string>
     <string name="bulk_label">Bulk:</string>

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
@@ -1,0 +1,196 @@
+package org.saudigitus.semis.attendance.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.saudigitus.semis.attendance.ui.repository.AttendanceRepository
+import org.saudigitus.semis.core.data.model.app_config.Attendance
+import org.saudigitus.semis.core.data.model.app_config.AttendanceStatus
+import org.saudigitus.semis.core.data.model.app_config.SEMISConfigItem
+import org.saudigitus.semis.core.data.repository.AppConfigRepository
+import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
+import org.saudigitus.semis.core.form.data.repository.FormRepository
+
+/**
+ * Covers the two configurations the app runs with: the attendance status flow enabled,
+ * where being present means holding no record, and disabled, where every learner does.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AttendanceResetTest {
+
+    private val formRepository: FormRepository = mock()
+    private val attendanceRepository: AttendanceRepository = mock()
+    private val appConfigRepository: AppConfigRepository = mock()
+    private val resourceManager = mock<org.dhis2.commons.resources.ResourceManager>()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        formRepository.stub {
+            on { attendanceButtonStateFlow } doReturn MutableStateFlow(AttendanceButtonState())
+            onBlocking {
+                loadAttendanceEvents(any(), any(), any(), any(), any(), anyOrNull())
+            } doReturn AttendanceButtonState()
+            onBlocking { deleteAttendance(any()) } doReturn AttendanceButtonState()
+        }
+        resourceManager.stub {
+            on { getString(any()) } doReturn "message"
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun attendanceConfig(allowStatus: Boolean) = Attendance(
+        absenceReason = "reason",
+        attendanceStatus = AttendanceStatus(
+            allowAttendanceStatus = allowStatus,
+            program = "status-program",
+            programStage = "status-stage",
+            totalRecords = "de_total",
+        ),
+        enabled = true,
+        lastUpdate = null,
+        programStage = "attendance-stage",
+        status = "de_status",
+        statusOptions = emptyList(),
+    )
+
+    private suspend fun viewModel(allowStatus: Boolean): AttendanceViewModel {
+        appConfigRepository.stub {
+            onBlocking { getSchoolCalendar() } doReturn null
+            onBlocking { getAppConfig(any()) } doReturn SEMISConfigItem(
+                absenteeism = null,
+                attendance = attendanceConfig(allowStatus),
+                defaults = null,
+                filters = null,
+                finalResult = null,
+                key = null,
+                lastUpdate = null,
+                performance = null,
+                program = "program",
+                reenroll = null,
+                registration = null,
+                socioEconomics = null,
+                trackedEntityType = null,
+                transfer = null,
+            )
+            onBlocking { allowedCalenderYearDates(any(), any()) } doReturn true
+        }
+
+        return AttendanceViewModel(
+            formRepository = formRepository,
+            attendanceRepository = attendanceRepository,
+            appConfigRepository = appConfigRepository,
+            resourceManager = resourceManager,
+        ).also {
+            it.initialize(
+                program = "program",
+                orgUnit = "orgUnit",
+                teis = emptyList(),
+                filterDetailsState = org.saudigitus.semis.core.designsystem.components
+                    .FilterDetailsState(),
+            )
+        }
+    }
+
+    @Test
+    fun `resetting asks for confirmation before anything is deleted`() = runTest {
+        val viewModel = viewModel(allowStatus = true)
+
+        viewModel.handleUiEvent(AttendanceUiEvent.ResetForm)
+
+        assert(viewModel.uiState.value.displayResetDialog)
+        verify(formRepository, never()).deleteAttendance(any())
+        verify(attendanceRepository, never()).updateAttendanceStatusSummary(
+            orgUnit = any(),
+            program = any(),
+            date = any(),
+            filterDetailsState = any(),
+            totalLearners = any(),
+            attendanceEvents = any(),
+        )
+    }
+
+    @Test
+    fun `dismissing the warning leaves the recorded attendance alone`() = runTest {
+        val viewModel = viewModel(allowStatus = true)
+
+        viewModel.handleUiEvent(AttendanceUiEvent.ResetForm)
+        viewModel.handleUiEvent(AttendanceUiEvent.DismissResetDialog)
+
+        assertFalse(viewModel.uiState.value.displayResetDialog)
+        verify(formRepository, never()).deleteAttendance(any())
+    }
+
+    @Test
+    fun `with the status flow on only the coded records go and the summary is rewritten`() =
+        runTest {
+            val viewModel = viewModel(allowStatus = true)
+
+            viewModel.handleUiEvent(AttendanceUiEvent.ConfirmResetForm)
+
+            verify(formRepository).deleteAttendance(absencesOnly = eq(true))
+            verify(attendanceRepository).updateAttendanceStatusSummary(
+                orgUnit = any(),
+                program = any(),
+                date = any(),
+                filterDetailsState = any(),
+                totalLearners = any(),
+                attendanceEvents = any(),
+            )
+        }
+
+    @Test
+    fun `without the status flow the whole date is cleared and no summary is written`() =
+        runTest {
+            val viewModel = viewModel(allowStatus = false)
+
+            viewModel.handleUiEvent(AttendanceUiEvent.ConfirmResetForm)
+
+            verify(formRepository).deleteAttendance(absencesOnly = eq(false))
+            verify(attendanceRepository, never()).updateAttendanceStatusSummary(
+                orgUnit = any(),
+                program = any(),
+                date = any(),
+                filterDetailsState = any(),
+                totalLearners = any(),
+                attendanceEvents = any(),
+            )
+        }
+
+    @Test
+    fun `the attendance status event is never deleted by a reset`() = runTest {
+        val viewModel = viewModel(allowStatus = true)
+
+        viewModel.handleUiEvent(AttendanceUiEvent.ConfirmResetForm)
+
+        verify(attendanceRepository, never()).createAttendanceStatus(any(), any(), any(), any())
+        verify(attendanceRepository, never()).completeAttendanceStatus(
+            orgUnit = any(),
+            program = any(),
+            date = any(),
+            filterDetailsState = any(),
+            totalLearners = any(),
+            attendanceEvents = any(),
+        )
+    }
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -41,6 +41,15 @@ interface AttendanceEventRepository {
         buttonModel: AttendanceButtonModel
     ): AttendanceButtonState
 
+    /**
+     * Deletes the attendance recorded for the loaded date.
+     *
+     * @param absencesOnly keeps the records whose value is not one of the configured
+     * coded statuses. The attendance status event lives on its own program stage and is
+     * never touched here.
+     */
+    suspend fun deleteAttendance(absencesOnly: Boolean): AttendanceButtonState
+
     fun updateAttendanceReason(tei: String, dataElement: String, value: String): AttendanceButtonState?
 
     suspend fun loadAttendanceEvents(

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceEventCleanup.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceEventCleanup.kt
@@ -1,0 +1,32 @@
+package org.saudigitus.semis.core.form.data.repository.impl
+
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+
+/**
+ * Records to delete when the attendance of a date is discarded.
+ *
+ * With the attendance status flow on, being present is the absence of a record, so only
+ * the coded statuses — absent, late and any other configured one — are stored and deleted.
+ * Without it every learner carries a record, so the whole date is cleared. Either way the
+ * attendance status event is on another program stage and is never part of this.
+ */
+internal fun removableAttendanceEvents(
+    events: List<AttendanceEventWithDecorator>,
+    configuredStatusCodes: List<String>,
+    absencesOnly: Boolean,
+): List<AttendanceEventWithDecorator> = events.filter { event ->
+    !absencesOnly || event.event?.value in configuredStatusCodes
+}
+
+/**
+ * Records that were loaded for the date but are no longer held by the form, so they have
+ * to be deleted on save instead of lingering with a status the learner no longer has.
+ */
+internal fun orphanedAttendanceEvents(
+    loaded: List<AttendanceEventWithDecorator>,
+    current: List<AttendanceEventWithDecorator>,
+): List<AttendanceEventWithDecorator> {
+    val keptTeis = current.mapNotNull { it.event?.tei }.toSet()
+
+    return loaded.filter { it.event?.tei !in keptTeis }
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -146,6 +146,30 @@ class FormRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun deleteAttendance(
+        absencesOnly: Boolean,
+    ): AttendanceButtonState = withContext(Dispatchers.IO) {
+        val current = attendanceButtonStateFlow.value
+        val removable = removableAttendanceEvents(
+            events = current.attendanceEvents,
+            configuredStatusCodes = current.buttons.mapNotNull { it.code },
+            absencesOnly = absencesOnly,
+        )
+
+        removable.forEach { event ->
+            event.event?.event?.let { uid -> eventRepository.deleteEvent(uid) }
+        }
+
+        val remaining = current.attendanceEvents - removable.toSet()
+        loadedAttendanceButtonState = loadedAttendanceButtonState.copy(
+            attendanceEvents = remaining,
+        )
+
+        return@withContext attendanceButtonState.updateAndGet {
+            it.copy(attendanceEvents = remaining)
+        }
+    }
+
     override fun updateAttendanceReason(
         tei: String,
         dataElement: String,
@@ -373,6 +397,15 @@ class FormRepositoryImpl @Inject constructor(
         programStage: String,
         attendanceEvents: List<AttendanceEventWithDecorator>
     ) = withContext(Dispatchers.IO) {
+        // A learner dropped from the form no longer holds a status, so the record loaded
+        // for them has to go with it rather than linger as a stale event.
+        orphanedAttendanceEvents(
+            loaded = loadedAttendanceButtonState.attendanceEvents,
+            current = attendanceEvents,
+        ).forEach { orphan ->
+            orphan.event?.event?.let { uid -> eventRepository.deleteEvent(uid) }
+        }
+
         attendanceEvents.forEach { attendanceEvent ->
             eventRepository.saveEvent(
                 event = attendanceEvent.event?.event,

--- a/semis/core/form/src/test/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceEventCleanupTest.kt
+++ b/semis/core/form/src/test/java/org/saudigitus/semis/core/form/data/repository/impl/AttendanceEventCleanupTest.kt
@@ -1,0 +1,114 @@
+package org.saudigitus.semis.core.form.data.repository.impl
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEvent
+import org.saudigitus.semis.core.designsystem.attendance.model.AttendanceEventWithDecorator
+
+class AttendanceEventCleanupTest {
+
+    private fun record(tei: String, value: String, eventUid: String? = "event-$tei") =
+        AttendanceEventWithDecorator(
+            event = AttendanceEvent(
+                tei = tei,
+                event = eventUid,
+                enrollment = "enrollment-$tei",
+                dataElement = "status",
+                value = value,
+                date = "2026-08-18",
+            ),
+        )
+
+    private val configuredCodes = listOf("ABSENT", "LATE")
+
+    @Test
+    fun `with the status flow on only the coded statuses are deleted`() {
+        val events = listOf(
+            record("a", "ABSENT"),
+            record("b", "LATE"),
+            record("c", ""),
+        )
+
+        val removable = removableAttendanceEvents(
+            events = events,
+            configuredStatusCodes = configuredCodes,
+            absencesOnly = true,
+        )
+
+        assertEquals(listOf("a", "b"), removable.map { it.event?.tei })
+    }
+
+    @Test
+    fun `without the status flow every record of the date is deleted`() {
+        val events = listOf(
+            record("a", "PRESENT"),
+            record("b", "ABSENT"),
+            record("c", "LATE"),
+        )
+
+        val removable = removableAttendanceEvents(
+            events = events,
+            configuredStatusCodes = configuredCodes,
+            absencesOnly = false,
+        )
+
+        assertEquals(listOf("a", "b", "c"), removable.map { it.event?.tei })
+    }
+
+    @Test
+    fun `a present record is kept while the status flow is on`() {
+        val events = listOf(record("a", "PRESENT"))
+
+        val removable = removableAttendanceEvents(
+            events = events,
+            configuredStatusCodes = configuredCodes,
+            absencesOnly = true,
+        )
+
+        assertEquals(emptyList<String>(), removable.map { it.event?.tei })
+    }
+
+    @Test
+    fun `nothing is removable when the date holds no record`() {
+        assertEquals(
+            emptyList<AttendanceEventWithDecorator>(),
+            removableAttendanceEvents(emptyList(), configuredCodes, absencesOnly = true),
+        )
+        assertEquals(
+            emptyList<AttendanceEventWithDecorator>(),
+            removableAttendanceEvents(emptyList(), configuredCodes, absencesOnly = false),
+        )
+    }
+
+    @Test
+    fun `a learner dropped from the form leaves an orphan to delete`() {
+        val loaded = listOf(record("a", "ABSENT"), record("b", "LATE"))
+        val current = listOf(record("a", "ABSENT"))
+
+        val orphans = orphanedAttendanceEvents(loaded = loaded, current = current)
+
+        assertEquals(listOf("b"), orphans.map { it.event?.tei })
+    }
+
+    @Test
+    fun `a learner whose status changed is not treated as an orphan`() {
+        val loaded = listOf(record("a", "ABSENT"))
+        val current = listOf(record("a", "LATE"))
+
+        assertEquals(
+            emptyList<String>(),
+            orphanedAttendanceEvents(loaded = loaded, current = current).map { it.event?.tei },
+        )
+    }
+
+    @Test
+    fun `clearing the form orphans every loaded record`() {
+        val loaded = listOf(record("a", "ABSENT"), record("b", "LATE"))
+
+        assertEquals(
+            listOf("a", "b"),
+            orphanedAttendanceEvents(loaded = loaded, current = emptyList())
+                .map { it.event?.tei },
+        )
+    }
+}


### PR DESCRIPTION
* Add a reset attendance workflow with a confirmation dialog and logic to clear recorded events for a specific date.
* Introduce `AttendanceCompletionNotice` to visually indicate whether a day's attendance is "Completed" or "Incomplete."
* Implement `deleteAttendance` in `FormRepository` to selectively remove records, supporting configurations where "Present" is the default (absence of a record).
* Add `orphanedAttendanceEvents` logic to ensure events for learners no longer in the form are cleaned up during persistence.
* Enhance `AttendanceRepository` with `updateAttendanceStatusSummary` to refresh status counters without finalizing the attendance event.
* Extend `AttendanceUiState` and `AttendanceViewModel` to handle reset dialog visibility and the `discardAttendance` lifecycle.
* Add unit tests for attendance event cleanup logic and the ViewModel's reset functionality.
* Update UI components and strings to support the reset warning and completion status messaging.