### PR TITLE
feat: enhance MarkInputField visual feedback for edit and focus states

### DIFF
--- a/semis/performance/src/main/java/org/saudigitus/semis/performance/performanceevent/components/MarkInputField.kt
+++ b/semis/performance/src/main/java/org/saudigitus/semis/performance/performanceevent/components/MarkInputField.kt
@@ -1,7 +1,12 @@
 package org.saudigitus.semis.performance.performanceevent.components
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -12,8 +17,11 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -21,13 +29,19 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
 import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+import org.saudigitus.semis.core.designsystem.theme.semisSoftShadow
 
 private val FieldShape = RoundedCornerShape(12.dp)
 private val NumericInput = "[-0-9.,]*".toRegex()
 
 /**
  * Compact box where the mark of a single learner is typed, rendered at the end of the roster row.
+ *
+ * While the list is read only the box stays filled with the page tint, and it turns white with a
+ * marked outline once the form is opened for edition, so tapping the action visibly unlocks the
+ * whole roster.
  */
 @Composable
 internal fun MarkInputField(
@@ -36,6 +50,29 @@ internal fun MarkInputField(
     modifier: Modifier = Modifier,
     onValueChange: (String) -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused by interactionSource.collectIsFocusedAsState()
+
+    val container by animateColorAsState(
+        targetValue = if (enabled) SemisPalette.CardSurface else SemisPalette.ScreenBackground,
+        animationSpec = tween(durationMillis = 180),
+        label = "mark_field_container",
+    )
+    val outline by animateColorAsState(
+        targetValue = when {
+            focused -> SemisAccent.Blue
+            enabled -> SemisAccent.Blue.copy(alpha = 0.45f)
+            else -> SemisPalette.CardBorder
+        },
+        animationSpec = tween(durationMillis = 180),
+        label = "mark_field_outline",
+    )
+    val outlineWidth by animateDpAsState(
+        targetValue = if (focused) 1.5.dp else 1.dp,
+        animationSpec = tween(durationMillis = 180),
+        label = "mark_field_outline_width",
+    )
+
     BasicTextField(
         modifier = modifier
             .width(72.dp)
@@ -44,8 +81,10 @@ internal fun MarkInputField(
         onValueChange = { typed -> if (typed.matches(NumericInput)) onValueChange(typed) },
         enabled = enabled,
         singleLine = true,
+        interactionSource = interactionSource,
+        cursorBrush = SolidColor(SemisAccent.Blue),
         textStyle = TextStyle(
-            color = SemisPalette.TextPrimary,
+            color = if (enabled) SemisPalette.TextPrimary else SemisPalette.TextSecondary,
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
@@ -58,8 +97,9 @@ internal fun MarkInputField(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = SemisPalette.ScreenBackground, shape = FieldShape)
-                    .border(width = 1.dp, color = SemisPalette.CardBorder, shape = FieldShape),
+                    .semisSoftShadow(FieldShape, elevation = if (enabled) 2.dp else 0.dp)
+                    .background(color = container, shape = FieldShape)
+                    .border(width = outlineWidth, color = outline, shape = FieldShape),
                 contentAlignment = Alignment.Center,
             ) {
                 if (value.isEmpty()) {


### PR DESCRIPTION
* Implement dynamic background and border color animations to visually distinguish between enabled, disabled, and focused states.
* Add focus state tracking via `MutableInteractionSource` to adjust outline thickness and color when the field is active.
* Update text styling to use `TextSecondary` when the field is read-only and `TextPrimary` when editable.
* Integrate `semisSoftShadow` and a custom blue cursor brush to improve the input experience.
* Refine component documentation to describe the visual transition between read-only and editable roster states.

## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-<ISSUE-NUMBER>).

Please provide a clear definition of the problem and explain your solution.