### PR TITLE
feat: refactor form to a single-page card-based layout and update the…

### DIFF
--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/designsystem/theme/FormSurfaces.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/designsystem/theme/FormSurfaces.kt
@@ -1,0 +1,38 @@
+package org.saudigitus.campaign.core.designsystem.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Surface tokens of the form screens. They mirror the palette used by the SEMIS module screens
+ * (white cards over a tinted page) without depending on the app design system, so the form stays
+ * portable.
+ */
+object FormSurfaces {
+    /** Header blue of the SEMIS design (SemisPalette.HeaderBlue). */
+    val HeaderBlue = Color(0xFF1B3F94)
+    val ScreenBackground = Color(0xFFEEF2F7)
+    val CardSurface = Color(0xFFFFFFFF)
+    val FieldSurface = Color(0xFFEEF2F7)
+    val SectionTitle = Color(0xFF1B4BA8)
+    val TextSecondary = Color(0xFF64748B)
+
+    /** Rounded box every field is drawn in. */
+    val FieldShape: Shape = RoundedCornerShape(12.dp)
+
+    /** Rounded top of the content sheet, as on the other module screens. */
+    val ScreenShape: Shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+}
+
+/** Soft elevation of the section cards, matching the cards of the module listings. */
+fun Modifier.formSoftShadow(shape: Shape, elevation: Dp = 4.dp): Modifier = shadow(
+    elevation = elevation,
+    shape = shape,
+    ambientColor = Color.Black.copy(alpha = 0.05f),
+    spotColor = Color.Black.copy(alpha = 0.10f),
+)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/designsystem/utils/SemisEnrollmentUtils.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/designsystem/utils/SemisEnrollmentUtils.kt
@@ -18,13 +18,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.IntSize
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 
 object Utils {
     @Composable
     fun inputColors() = TextFieldDefaults.colors(
-        focusedContainerColor = Color.White,
-        unfocusedContainerColor = Color.White,
-        disabledContainerColor = Color.White,
+        focusedContainerColor = FormSurfaces.FieldSurface,
+        unfocusedContainerColor = FormSurfaces.FieldSurface,
+        disabledContainerColor = FormSurfaces.FieldSurface,
         focusedIndicatorColor = Color.Transparent,
         unfocusedIndicatorColor = Color.Transparent,
         disabledIndicatorColor = Color.Transparent,

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/FormFieldItem.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/FormFieldItem.kt
@@ -40,7 +40,7 @@ fun FormFieldItem(
     onValueChange: (String) -> Unit
 ) {
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/CoordinateField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/CoordinateField.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.theme.dark_warning
 import org.saudigitus.campaign.core.designsystem.theme.light_green
 import org.saudigitus.campaign.core.designsystem.theme.light_success
@@ -49,6 +50,7 @@ fun CoordinateField(
         horizontalAlignment = Alignment.Start
     ) {
         TextField(
+            shape = FormSurfaces.FieldShape,
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(Spacing.Spacing0, 300.dp)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/DateField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/DateField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.saudigitus.campaign.core.designsystem.components.CustomDatePicker
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.form.R
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.utils.Utils
@@ -43,6 +44,7 @@ fun DateField(
     )
 
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(Spacing.Spacing0, 300.dp)
@@ -103,6 +105,7 @@ fun DateField(
     )
 
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(Spacing.Spacing0, 300.dp)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/Dropdown.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/Dropdown.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.window.PopupProperties
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.theme.seed
 import org.saudigitus.campaign.core.form.R
 import org.saudigitus.campaign.core.form.utils.Utils
@@ -84,6 +85,7 @@ fun <T> DropdownField(
 
     Column {
         TextField(
+            shape = FormSurfaces.FieldShape,
             value = selectedText,
             onValueChange = {},
             label = { Text(text = label) },

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/InputField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/InputField.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import org.dhis2.composetable.model.extensions.keyboardCapitalization
 import org.dhis2.composetable.model.extensions.toKeyboardType
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.utils.Utils
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.utils.toKeyBoardInputType
@@ -36,6 +37,7 @@ fun InputField(
     colors: TextFieldColors = Utils.inputColors(),
 ) {
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(Spacing.Spacing0, 300.dp)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/OuField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/OuField.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.saudigitus.campaign.core.data.models.OrgUnit
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.utils.Utils
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 
@@ -22,6 +23,7 @@ fun OuField(
     onItemClick: (OrgUnit) -> Unit,
 ) {
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier.fillMaxWidth().then(modifier),
         value = selectedOrgUnit?.displayName.orEmpty(),
         onValueChange = {},
@@ -39,6 +41,7 @@ fun OuField(
     onValueChange: (String) -> Unit,
 ) {
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier.fillMaxWidth().then(modifier),
         value = field.value.orEmpty(),
         onValueChange = onValueChange,

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/PhoneNumberField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/PhoneNumberField.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.utils.Utils
 import org.saudigitus.campaign.core.form.R
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
@@ -31,6 +32,7 @@ fun PhoneNumberField(
     colors: TextFieldColors = Utils.inputColors(),
 ) {
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(Spacing.Spacing0, 300.dp)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/QRField.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/QRField.kt
@@ -28,6 +28,7 @@ import org.dhis2.composetable.model.extensions.keyboardCapitalization
 import org.dhis2.composetable.model.extensions.toKeyboardType
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.saudigitus.campaign.core.data.models.QrResult
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.utils.Utils
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.utils.toKeyBoardInputType
@@ -55,6 +56,7 @@ fun QRField(
 
 
     TextField(
+        shape = FormSurfaces.FieldShape,
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(Spacing.Spacing0, 300.dp)

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/SearchableDropdown.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/SearchableDropdown.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.window.PopupProperties
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.utils.Utils
 
@@ -71,6 +72,7 @@ fun SearchableDropdown(
 
     Column {
         TextField(
+            shape = FormSurfaces.FieldShape,
             value = selectedText,
             onValueChange = {
                 selectedText = it

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/SearchableOrgUnitDropdown.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/fields/SearchableOrgUnitDropdown.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.window.PopupProperties
 import org.hisp.dhis.mobile.ui.designsystem.theme.Spacing
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.form.R
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.utils.Utils
@@ -78,6 +79,7 @@ fun SearchableOrgUnitDropdown(
 
     Column {
         TextField(
+            shape = FormSurfaces.FieldShape,
             value = selectedText,
             onValueChange = {
                 selectedText = it

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/section/FormSectionCard.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/section/FormSectionCard.kt
@@ -1,0 +1,97 @@
+package org.saudigitus.campaign.core.form.ui.section
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
+import org.saudigitus.campaign.core.designsystem.theme.formSoftShadow
+import org.saudigitus.campaign.core.form.data.models.FormSectionModel
+import org.saudigitus.campaign.core.form.ui.FormFieldItem
+import org.saudigitus.campaign.core.form.ui.component.MandatoryFieldWrapper
+import org.saudigitus.campaign.core.form.ui.state.FormEvent
+import org.saudigitus.campaign.core.utils.location.state.CoordinateState
+
+private val SectionShape = RoundedCornerShape(20.dp)
+
+/**
+ * A form section laid out as a card: its name and description on top and every rendered field
+ * underneath, so the whole form reads as a single scroll instead of one page per section.
+ */
+@Composable
+internal fun FormSectionCard(
+    section: FormSectionModel,
+    showMandatoryError: Boolean,
+    coordinateStates: Map<String, CoordinateState>,
+    modifier: Modifier = Modifier,
+    onEvent: (FormEvent) -> Unit,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .formSoftShadow(SectionShape),
+        shape = SectionShape,
+        colors = CardDefaults.cardColors(containerColor = FormSurfaces.CardSurface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            section.name?.takeIf { it.isNotBlank() }?.let { name ->
+                Text(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    text = name.uppercase(),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = FormSurfaces.SectionTitle,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 0.8.sp,
+                )
+            }
+
+            section.description?.takeIf { it.isNotBlank() }?.let { description ->
+                Text(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = FormSurfaces.TextSecondary,
+                )
+            }
+
+            section.formFields.filter { it.rendered == true }.forEach { field ->
+                val fieldItem: @Composable () -> Unit = {
+                    FormFieldItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        field = field,
+                        enabled = field.enabled,
+                        coordinateState = coordinateStates[field.uid],
+                        onValueChange = { value ->
+                            onEvent(FormEvent.UpdateField(section, field.uid, value))
+                        },
+                        onQuery = { fieldModel, query ->
+                            onEvent(FormEvent.SearchFieldQuery(section, fieldModel.uid, query))
+                        },
+                    )
+                }
+
+                if (field.mandatory == true) {
+                    MandatoryFieldWrapper(showMandatoryError) { fieldItem() }
+                } else {
+                    fieldItem()
+                }
+            }
+        }
+    }
+}

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/section/FormSectionUi.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/ui/section/FormSectionUi.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,10 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PinDrop
@@ -24,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -39,17 +37,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.hisp.dhis.android.core.common.ValueType
-import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
 import org.saudigitus.campaign.core.designsystem.templates.SimpleScaffold
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 import org.saudigitus.campaign.core.designsystem.theme.light_success
 import org.saudigitus.campaign.core.form.R
-import org.saudigitus.campaign.core.form.ui.FormFieldItem
 import org.saudigitus.campaign.core.form.ui.component.FormInfo
 import org.saudigitus.campaign.core.form.ui.component.MandatoryFieldWrapper
 import org.saudigitus.campaign.core.form.ui.fields.DateField
@@ -57,10 +54,8 @@ import org.saudigitus.campaign.core.form.ui.fields.OuField
 import org.saudigitus.campaign.core.form.ui.state.FormEvent
 import org.saudigitus.campaign.core.form.ui.state.FormSectionType
 import org.saudigitus.campaign.core.form.ui.state.FormSectionUiState
-import org.saudigitus.campaign.core.form.utils.checkUnfilledMandatoryFields
 import org.saudigitus.campaign.core.form.utils.completionPercentage
 import org.saudigitus.campaign.core.form.utils.firstBlockingFieldIndex
-import org.saudigitus.campaign.core.utils.IdGenerator
 import org.saudigitus.campaign.core.utils.location.rememberCoordinateState
 import org.saudigitus.campaign.core.utils.location.state.CoordinateState
 
@@ -75,16 +70,8 @@ internal fun FormSectionUi(
         section.rendered && section.formFields.any { field -> field.rendered == true }
     }
     val hasVisibleSections = visibleSections.isNotEmpty()
-    val pagerState = rememberPagerState { maxOf(visibleSections.size, 1) }
+    val listState = rememberLazyListState()
     val scrollScope = rememberCoroutineScope()
-    val lazyListState = remember(pagerState.pageCount) {
-        List(pagerState.pageCount) { LazyListState() }
-    }
-    val currentPage = if (hasVisibleSections) {
-        pagerState.currentPage.coerceIn(0, visibleSections.lastIndex)
-    } else {
-        0
-    }
 
     val animatedProgress by animateFloatAsState(
         targetValue = visibleSections.completionPercentage(),
@@ -95,7 +82,7 @@ internal fun FormSectionUi(
     var finishedCoordinateFields by remember { mutableStateOf(emptySet<String>()) }
     var coordinateStatesByField by remember { mutableStateOf(emptyMap<String, CoordinateState>()) }
 
-    val currentCoordinateCandidate = visibleSections.getOrNull(currentPage)?.let { section ->
+    val currentCoordinateCandidate = visibleSections.firstNotNullOfOrNull { section ->
         section.formFields
             .filter { field ->
                 field.rendered == true && field.valueType == ValueType.COORDINATE
@@ -160,18 +147,23 @@ internal fun FormSectionUi(
         )
     }
 
-    fun isCurrentPageValid(): Boolean {
+    val showsBaseFields = state.formType == FormSectionType.NEW_ENROLLMENT ||
+        state.formType == FormSectionType.EDIT_ENROLLMENT ||
+        state.formType == FormSectionType.NEW_EVENT_WITHOUT_REGISTRATION
+    val pendingMandatorySection = visibleSections.firstOrNull { it.hasUnfilledMandatoryFields() }
+
+    // The header sits inside the list, so the sections start right after it.
+    val sectionsOffset = if (showsBaseFields || pendingMandatorySection != null) 1 else 0
+
+    fun isFormValid(): Boolean {
         hasUnfilledMandatoryFields = hasBaseMandatoryFields(state) ||
-            (hasVisibleSections && visibleSections[currentPage].hasUnfilledMandatoryFields())
+            visibleSections.any { it.hasUnfilledMandatoryFields() }
 
-        val firstBlockingFieldIndex = visibleSections
-            .getOrNull(currentPage)
-            ?.firstBlockingFieldIndex()
-            ?: -1
+        val blockingSection = visibleSections.indexOfFirst { it.firstBlockingFieldIndex() != -1 }
 
-        if (firstBlockingFieldIndex != -1) {
+        if (blockingSection != -1) {
             scrollScope.launch {
-                lazyListState[currentPage].animateScrollToItem(firstBlockingFieldIndex)
+                listState.animateScrollToItem(blockingSection + sectionsOffset)
             }
 
             return false
@@ -191,43 +183,23 @@ internal fun FormSectionUi(
                         verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
                         horizontalAlignment = Alignment.Start
                     ) {
-                        if (hasVisibleSections) {
-                            Text(
-                                visibleSections[currentPage].name.orEmpty(),
-                                style = MaterialTheme.typography.titleLarge
-                            )
-                            visibleSections[currentPage].description?.let {
-                                Text(
-                                    it,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    softWrap = true,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                        }
+                        Text(
+                            stringResource(R.string.form_title),
+                            style = MaterialTheme.typography.titleLarge
+                        )
 
-                        Column(
-                            verticalArrangement = Arrangement.Top,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            if (hasVisibleSections) {
-                                Text(
-                                    "${currentPage + 1} of ${visibleSections.size}",
-                                    style = MaterialTheme.typography.labelMedium
-                                )
-                                LinearProgressIndicator(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    trackColor = Color.White,
-                                    color = light_success,
-                                    progress = { animatedProgress }
-                                )
-                            }
+                        if (hasVisibleSections) {
+                            LinearProgressIndicator(
+                                modifier = Modifier.fillMaxWidth(),
+                                trackColor = Color.White,
+                                color = light_success,
+                                progress = { animatedProgress }
+                            )
                         }
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = SurfaceColor.Primary,
+                    containerColor = FormSurfaces.HeaderBlue,
                     navigationIconContentColor = Color.White,
                     titleContentColor = Color.White,
                     actionIconContentColor = Color.White,
@@ -252,177 +224,74 @@ internal fun FormSectionUi(
                 horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (pagerState.pageCount == 1) {
-                    Button(
-                        modifier = Modifier.fillMaxWidth(),
-                        onClick = {
-                            if (isCurrentPageValid()) {
-                                onEvent(FormEvent.ConfirmSave)
-                            }
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        if (isFormValid()) {
+                            onEvent(FormEvent.ConfirmSave)
                         }
-                    ) {
-                        Text(stringResource(R.string.save))
                     }
-                } else {
-                    OutlinedButton(
-                        modifier = Modifier.weight(1f),
-                        enabled = pagerState.canScrollBackward,
-                        onClick = {
-                            if (pagerState.canScrollBackward) {
-                                scrollScope.launch {
-                                    pagerState.animateScrollToPage(page = pagerState.currentPage - 1)
-                                }
-                            }
-                        }
-                    ) {
-                        Text(stringResource(R.string.previous))
-                    }
-                    Button(
-                        modifier = Modifier.weight(1f),
-                        onClick = {
-                            val isValid = isCurrentPageValid()
-
-                            if (pagerState.canScrollForward && isValid) {
-                                scrollScope.launch {
-                                    pagerState.animateScrollToPage(page = pagerState.currentPage + 1)
-                                }
-                            } else if (isValid) {
-                                onEvent(FormEvent.ConfirmSave)
-                            }
-                        }
-                    ) {
-                        Text(
-                            text = if (pagerState.canScrollForward) {
-                                stringResource(R.string.next)
-                            } else stringResource(R.string.save)
-                        )
-                    }
+                ) {
+                    Text(stringResource(R.string.save))
                 }
             }
         },
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) {
-        Column(
+        LazyColumn(
             modifier = Modifier
-                .then(modifier)
+                .fillMaxSize()
+                .background(FormSurfaces.HeaderBlue)
+                .clip(FormSurfaces.ScreenShape)
+                .background(FormSurfaces.ScreenBackground)
+                .then(modifier),
+            state = listState,
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
         ) {
-            if (
-                state.formType == FormSectionType.NEW_ENROLLMENT ||
-                state.formType == FormSectionType.EDIT_ENROLLMENT ||
-                state.formType == FormSectionType.NEW_EVENT_WITHOUT_REGISTRATION
-            ) {
-                MandatoryFieldWrapper(hasUnfilledMandatoryFields) {
-                    OuField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 5.dp),
-                        placeholder = stringResource(R.string.administrative_area),
-                        leadingIcon = Icons.Default.PinDrop,
-                        selectedOrgUnit = state.orgUnit,
-                        program = state.program.orEmpty()
-                    ) {
-                        hasUnfilledMandatoryFields = false
-                        onEvent(FormEvent.SelectedOU(it))
-                    }
-                }
-
-                DateField(
-                    isEnabled = false,
-                    date = visibleSections.firstOrNull()?.registrationDate,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 5.dp)
-                ) {
-                    onEvent(FormEvent.SelectedDate(it))
-                }
-            }
-
-            if (hasVisibleSections && visibleSections.checkUnfilledMandatoryFields()) {
-                FormInfo(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    formSectionModel = visibleSections[currentPage]
-                )
-            }
-
-            if (hasVisibleSections) {
-                HorizontalPager(
-                    modifier = Modifier.fillMaxSize(),
-                    state = pagerState,
-                    userScrollEnabled = false,
-                    verticalAlignment = Alignment.Top,
-                    key = {
-                        visibleSections.getOrNull(it)?.uid
-                            ?: IdGenerator.generateDhis2PatternId()
-                    }
-                ) { page ->
-                    LazyColumn(
-                        modifier = Modifier.fillMaxWidth(),
-                        state = lazyListState[page],
-                        verticalArrangement = Arrangement.Top,
-                        horizontalAlignment = Alignment.Start,
-                    ) {
-                        items(
-                            visibleSections[page].formFields.filter { it.rendered == true },
-                            key = { it.uid }
-                        ) { field ->
-                            if (field.mandatory == true) {
-                                MandatoryFieldWrapper(hasUnfilledMandatoryFields) {
-                                    FormFieldItem(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        field = field,
-                                        enabled = field.enabled,
-                                        coordinateState = coordinateStatesByField[field.uid],
-                                        onValueChange = { value ->
-                                            onEvent(
-                                                FormEvent.UpdateField(
-                                                    visibleSections[page],
-                                                    field.uid,
-                                                    value
-                                                )
-                                            )
-                                        },
-                                        onQuery = { fieldModel, query ->
-                                            onEvent(
-                                                FormEvent.SearchFieldQuery(
-                                                    visibleSections[page],
-                                                    fieldModel.uid,
-                                                    query
-                                                )
-                                            )
-                                        }
-                                    )
-                                }
-                            } else {
-                                FormFieldItem(
+            if (sectionsOffset == 1) {
+                item(key = "form_header") {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        if (showsBaseFields) {
+                            MandatoryFieldWrapper(hasUnfilledMandatoryFields) {
+                                OuField(
                                     modifier = Modifier.fillMaxWidth(),
-                                    field = field,
-                                    enabled = field.enabled,
-                                    coordinateState = coordinateStatesByField[field.uid],
-                                    onValueChange = { value ->
-                                        onEvent(
-                                            FormEvent.UpdateField(
-                                                visibleSections[page],
-                                                field.uid,
-                                                value
-                                            )
-                                        )
-                                    },
-                                    onQuery = { fieldModel, query ->
-                                        onEvent(
-                                            FormEvent.SearchFieldQuery(
-                                                visibleSections[page],
-                                                fieldModel.uid,
-                                                query
-                                            )
-                                        )
-                                    }
-                                )
+                                    placeholder = stringResource(R.string.administrative_area),
+                                    leadingIcon = Icons.Default.PinDrop,
+                                    selectedOrgUnit = state.orgUnit,
+                                    program = state.program.orEmpty()
+                                ) {
+                                    hasUnfilledMandatoryFields = false
+                                    onEvent(FormEvent.SelectedOU(it))
+                                }
                             }
+
+                            DateField(
+                                isEnabled = false,
+                                date = visibleSections.firstOrNull()?.registrationDate,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                onEvent(FormEvent.SelectedDate(it))
+                            }
+                        }
+
+                        pendingMandatorySection?.let { section ->
+                            FormInfo(
+                                modifier = Modifier.fillMaxWidth(),
+                                formSectionModel = section
+                            )
                         }
                     }
                 }
+            }
+
+            items(visibleSections, key = { it.uid }) { section ->
+                FormSectionCard(
+                    section = section,
+                    showMandatoryError = hasUnfilledMandatoryFields,
+                    coordinateStates = coordinateStatesByField,
+                    onEvent = onEvent,
+                )
             }
         }
     }

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/utils/Utils.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/utils/Utils.kt
@@ -2,27 +2,33 @@ package org.saudigitus.campaign.core.form.utils
 
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import org.hisp.dhis.mobile.ui.designsystem.component.InputShellState
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.campaign.core.designsystem.theme.FormSurfaces
 
 object Utils {
+    /**
+     * Fields are drawn as tinted boxes over the white section cards, so the indicator line of the
+     * filled text field is dropped and the error state is carried by the container and the
+     * supporting text.
+     */
     @Composable
     fun inputColors() = TextFieldDefaults.colors(
-        focusedContainerColor = SurfaceColor.Surface,
-        focusedIndicatorColor = InputShellState.FOCUSED.color,
+        focusedContainerColor = FormSurfaces.FieldSurface,
+        focusedIndicatorColor = Color.Transparent,
         focusedLabelColor = InputShellState.FOCUSED.color,
         focusedLeadingIconColor = InputShellState.FOCUSED.color,
-        focusedPlaceholderColor = InputShellState.FOCUSED.color,
         focusedTrailingIconColor = InputShellState.FOCUSED.color,
-        unfocusedContainerColor = SurfaceColor.Surface,
-        unfocusedIndicatorColor = SurfaceColor.Surface,
+        unfocusedContainerColor = FormSurfaces.FieldSurface,
+        unfocusedIndicatorColor = Color.Transparent,
         disabledContainerColor = SurfaceColor.DisabledSurface,
-        disabledIndicatorColor = SurfaceColor.Surface,
+        disabledIndicatorColor = Color.Transparent,
         disabledTextColor = InputShellState.DISABLED.color,
         disabledLabelColor = InputShellState.DISABLED.color,
         disabledPlaceholderColor = InputShellState.DISABLED.color,
         errorContainerColor = SurfaceColor.ErrorContainer,
-        errorIndicatorColor = SurfaceColor.Error,
+        errorIndicatorColor = Color.Transparent,
         errorCursorColor = InputShellState.ERROR.color,
         errorLabelColor = InputShellState.ERROR.color,
         errorLeadingIconColor = InputShellState.ERROR.color,


### PR DESCRIPTION
…me tokens

* Refactor the form workflow from a multi-page `HorizontalPager` to a single-page unified scroll using `LazyColumn`.
* Introduce `FormSectionCard` to display form sections as discrete, shadowed cards with integrated titles and descriptions.
* Implement `FormSurfaces` design tokens to standardize colors (HeaderBlue, FieldSurface, CardSurface) and shapes (FieldShape, ScreenShape) across the form module.
* Update all input fields (Date, QR, Coordinate, Dropdown, etc.) to utilize a rounded background shape and remove the default text field indicator lines.
* Streamline form navigation by replacing pagination controls (Next/Previous) with a single, full-width Save action button.
* Enhance validation logic to perform global mandatory field checks and auto-scroll to the first blocking error across all sections.
* Adjust `FormFieldItem` layout with increased vertical padding for improved field separation.
* Standardize the form header (`TopAppBar`) with branded colors and a persistent completion progress indicator.
* Add a `formSoftShadow` modifier to match the elevation style of other application modules.

## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/ANDROAPP-<ISSUE-NUMBER>).

Please provide a clear definition of the problem and explain your solution.