### PR TITLE
refactor: standardize form field styling and introduce FormFieldDefaults

### DIFF
--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/Dropdown.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/Dropdown.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.semis.core.designsystem.theme.SemisFieldShape
 
 @Composable
 fun <T> DropdownField(
@@ -77,6 +78,7 @@ fun <T> DropdownField(
 
     Column {
         TextField(
+            shape = SemisFieldShape,
             value = selectedText,
             onValueChange = {},
             label = { Text(text = label) },

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/SemisSurfaces.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/SemisSurfaces.kt
@@ -26,6 +26,9 @@ object SemisAccent {
 /** Shape of the content area right below the toolbar. */
 val SemisScreenShape: Shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
 
+/** Rounded box the form fields are drawn in, as on the enrollment form. */
+val SemisFieldShape: Shape = RoundedCornerShape(12.dp)
+
 /** Soft elevation used by the SEMIS cards, mirroring the transfer module look. */
 fun Modifier.semisSoftShadow(shape: Shape, elevation: Dp = 4.dp): Modifier = shadow(
     elevation = elevation,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldDefaults.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldDefaults.kt
@@ -1,0 +1,27 @@
+package org.saudigitus.semis.core.form.ui
+
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import org.hisp.dhis.mobile.ui.designsystem.theme.SurfaceColor
+import org.saudigitus.semis.core.designsystem.theme.SemisFieldShape
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+
+object FormFieldDefaults {
+
+    val Shape: Shape = SemisFieldShape
+
+    @Composable
+    fun colors(): TextFieldColors = TextFieldDefaults.colors(
+        focusedContainerColor = SemisPalette.ScreenBackground,
+        unfocusedContainerColor = SemisPalette.ScreenBackground,
+        disabledContainerColor = SurfaceColor.DisabledSurface,
+        errorContainerColor = SurfaceColor.ErrorContainer,
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent,
+        disabledIndicatorColor = Color.Transparent,
+        errorIndicatorColor = Color.Transparent,
+    )
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldItem.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/FormFieldItem.kt
@@ -5,14 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.TextFieldColors
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.hisp.dhis.android.core.common.ValueType
-import org.hisp.dhis.mobile.ui.designsystem.component.InputShellState
 import org.saudigitus.semis.core.data.model.OrgUnit
 import org.saudigitus.semis.core.designsystem.attendance.AttendanceButton
 import org.saudigitus.semis.core.designsystem.attendance.AttendanceButtonState
@@ -35,11 +32,7 @@ fun FormFieldItem(
     enabled: Boolean? = null,
     fieldsData: List<FormFieldData> = emptyList(),
     attendanceButtonState: AttendanceButtonState = AttendanceButtonState(),
-    colors: TextFieldColors = TextFieldDefaults.colors(
-        focusedIndicatorColor = InputShellState.FOCUSED.color,
-        unfocusedIndicatorColor = InputShellState.UNFOCUSED.color,
-        disabledIndicatorColor = InputShellState.DISABLED.color,
-    ),
+    colors: TextFieldColors = FormFieldDefaults.colors(),
     onAttendanceChange: (AttendanceButtonModel) -> Unit = {},
     onOrganisationUnitChange: (OrgUnit) -> Unit = {},
     onValueChange: (String) -> Unit
@@ -64,11 +57,7 @@ fun FormFieldItem(
                     program = program,
                     modifier = Modifier.fillMaxWidth(),
                     enabled = (enabled ?: true) && field.enabled,
-                    colors = TextFieldDefaults.colors(
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = InputShellState.UNFOCUSED.color,
-                        disabledIndicatorColor = InputShellState.DISABLED.color,
-                    ),
+                    colors = colors,
                     onValueChange = onOrganisationUnitChange,
                 )
             }
@@ -86,12 +75,7 @@ fun FormFieldItem(
                         field,
                         formFieldData = fieldData,
                         enabled = enabled,
-                        colors =
-                            TextFieldDefaults.colors(
-                                focusedIndicatorColor = Color.Transparent,
-                                unfocusedIndicatorColor = InputShellState.UNFOCUSED.color,
-                                disabledIndicatorColor = InputShellState.DISABLED.color,
-                            ),
+                        colors = colors,
                         onValueChange
                     )
                 }

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/fields/InputField.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/ui/fields/InputField.kt
@@ -30,6 +30,7 @@ import org.dhis2.composetable.model.extensions.keyboardCapitalization
 import org.dhis2.composetable.model.extensions.toKeyboardType
 import org.saudigitus.semis.core.designsystem.utils.IntentAction
 import org.saudigitus.semis.core.form.data.model.FormFieldData
+import org.saudigitus.semis.core.form.ui.FormFieldDefaults
 import org.saudigitus.semis.core.form.data.model.FormFieldState
 import org.saudigitus.semis.core.form.utils.toKeyBoardInputType
 
@@ -54,6 +55,7 @@ fun InputField(
 
     TextField(
         modifier = modifier,
+        shape = FormFieldDefaults.Shape,
         enabled = enable ?: field.enabled,
         value = field.value ?: formFieldData?.value.orEmpty(),
         onValueChange = onValueChange,


### PR DESCRIPTION
* Introduce `FormFieldDefaults` to centralize common `TextField` styling, including colors and shapes.
* Add `SemisFieldShape` to the design system theme, providing a consistent 12dp rounded corner for input fields.
* Apply `SemisFieldShape` to `DropdownField` and `InputField` components to ensure UI consistency.
* Refactor `FormFieldItem` to utilize `FormFieldDefaults.colors()`, replacing manual `TextFieldColors` definitions.
* Update form field color configuration to use `SemisPalette.ScreenBackground` for containers and hide indicators by setting them to transparent.