### PR TITLE
feat: implement student profile dashboard and performance tracking

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
@@ -17,6 +17,9 @@ import org.saudigitus.semis.app.presentation.tei.TeiListScreen
 import org.saudigitus.semis.attendance.ui.AttendanceUi
 import org.saudigitus.semis.attendance.ui.AttendanceViewModel
 import org.saudigitus.semis.enrollment.ui.EnrollmentScreen
+import org.saudigitus.semis.enrollment.ui.profile.StudentProfileEvent
+import org.saudigitus.semis.enrollment.ui.profile.StudentProfileScreen
+import org.saudigitus.semis.enrollment.ui.profile.StudentProfileViewModel
 import org.saudigitus.semis.enrollment.ui.form.SemisCoreEnrollmentFormScreen
 import org.saudigitus.semis.enrollment.ui.form.initializeSemisCoreForm
 import org.saudigitus.semis.core.designsystem.utils.mapper.TEICardMapper
@@ -58,12 +61,41 @@ fun AppNavGraph(
                         is TeiListEvent.OnBack -> navController.navigateUp()
                         is TeiListEvent.OnSyncClick -> syncData()
                         is TeiListEvent.OnTeiClick -> {
-
+                            navController.navigate(AppRoutes.studentProfile(it.tei))
                         }
 
                         is TeiListEvent.DisplayImageDetail -> displayImageDetail(it.imagePath)
                     }
                 }
+            )
+        }
+        composable(route = AppRoutes.STUDENT_PROFILE_ROUTE) { entry ->
+            val homeState by viewModel.uiState.collectAsStateWithLifecycle()
+            val profileViewModel = hiltViewModel<StudentProfileViewModel>()
+            val teiUid = entry.arguments
+                ?.getString(AppRoutes.STUDENT_PROFILE_ARG_TEI)
+                .orEmpty()
+
+            LaunchedEffect(key1 = teiUid, key2 = homeState.program) {
+                if (teiUid.isNotBlank() && homeState.program.isNotBlank()) {
+                    profileViewModel.initialize(
+                        teiUid = teiUid,
+                        program = homeState.program,
+                        filterDetailsState = homeState.filterState.filterDetailsState,
+                    )
+                }
+            }
+
+            val profileState by profileViewModel.uiState.collectAsStateWithLifecycle()
+
+            StudentProfileScreen(
+                state = profileState,
+                onEvent = { event ->
+                    when (event) {
+                        is StudentProfileEvent.OnBack -> navController.navigateUp()
+                        else -> profileViewModel.handleEvent(event)
+                    }
+                },
             )
         }
         composable(route = AppRoutes.ATTENDANCE) {
@@ -101,6 +133,9 @@ fun AppNavGraph(
                 onNewEnrollment = {
                     initializeSemisCoreForm()
                     navController.navigate(AppRoutes.ENROLLMENT_FORM)
+                },
+                onTeiClick = { teiUid ->
+                    navController.navigate(AppRoutes.studentProfile(teiUid))
                 },
             )
         }

--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/navigation/AppRoutes.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/navigation/AppRoutes.kt
@@ -9,4 +9,11 @@ object AppRoutes {
     const val PERFORMANCE = "performance"
     const val TRANSFER = "transfer"
     const val HOME = "home"
+
+    /** Learner dashboard, opened from the tracker listing with the record uid. */
+    const val STUDENT_PROFILE = "student/profile"
+    const val STUDENT_PROFILE_ARG_TEI = "teiUid"
+    const val STUDENT_PROFILE_ROUTE = "student/profile/{teiUid}"
+
+    fun studentProfile(teiUid: String) = "student/profile/" + teiUid
 }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceHeader.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceHeader.kt
@@ -18,6 +18,7 @@ import org.saudigitus.semis.attendance.R
 import org.saudigitus.semis.core.designsystem.components.CustomDatePicker
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
 import org.saudigitus.semis.core.designsystem.components.buttons.TonalIconButton
+import org.saudigitus.semis.core.designsystem.components.filters.FilterDetailsInfoCard
 import org.saudigitus.semis.core.designsystem.components.header.HeaderTitleBar
 import org.saudigitus.semis.core.designsystem.components.header.RoundedBottomHeader
 import org.saudigitus.semis.core.designsystem.components.model.ToolbarHeaders
@@ -89,7 +90,7 @@ internal fun AttendanceHeader(
             },
         )
 
-        AttendanceFilterInfo(state = filterDetailsState)
+        FilterDetailsInfoCard(state = filterDetailsState)
 
         StatTileRow(tiles = tiles)
     }

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/di/DataModule.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/di/DataModule.kt
@@ -23,6 +23,8 @@ import org.saudigitus.semis.core.data.repository.ProgramStageRepository
 import org.saudigitus.semis.core.data.repository.ProgramStageRepositoryImpl
 import org.saudigitus.semis.core.data.repository.TeiDownloaderRepository
 import org.saudigitus.semis.core.data.repository.TeiDownloaderRepositoryImpl
+import org.saudigitus.semis.core.data.repository.TeiProfileRepository
+import org.saudigitus.semis.core.data.repository.TeiProfileRepositoryImpl
 import org.saudigitus.semis.core.data.repository.TeiRepository
 import org.saudigitus.semis.core.data.repository.TeiRepositoryImpl
 import org.saudigitus.semis.core.data.repository.TeiTransferRepository
@@ -81,6 +83,18 @@ object DataModule {
         d2: D2,
         transformations: Transformations
     ): TeiRepository = TeiRepositoryImpl(d2, transformations)
+
+    @Provides
+    @Singleton
+    fun provideTeiProfileRepository(
+        d2: D2,
+        appConfigRepository: AppConfigRepository,
+        transformations: Transformations,
+    ): TeiProfileRepository = TeiProfileRepositoryImpl(
+        d2 = d2,
+        appConfigRepository = appConfigRepository,
+        transformations = transformations,
+    )
 
     @Provides
     @Singleton

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceHistory.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceHistory.kt
@@ -1,0 +1,15 @@
+package org.saudigitus.semis.core.data.model.profile
+
+/**
+ * Attendance a learner accumulated over the selected academic year.
+ *
+ * [statusCounts] holds one entry per configured attendance status, counting zero when the
+ * learner has no day of it, so the counters only disappear when the program configures no
+ * status at all.
+ */
+data class AttendanceHistory(
+    val records: List<AttendanceRecord> = emptyList(),
+    val statusCounts: List<AttendanceStatusCount> = emptyList(),
+) {
+    val recordedDays: Int get() = records.size
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceRecord.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceRecord.kt
@@ -1,0 +1,14 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import java.util.Date
+
+/**
+ * A single day of attendance recorded for a learner.
+ */
+data class AttendanceRecord(
+    val eventUid: String,
+    val date: Date?,
+    val statusCode: String,
+    val statusLabel: String,
+    val absenceReason: String?,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCount.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCount.kt
@@ -1,0 +1,16 @@
+package org.saudigitus.semis.core.data.model.profile
+
+/**
+ * How many days a learner holds of one configured attendance status.
+ *
+ * Every configured status is reported, whether or not the learner has a day of it, so the
+ * dashboard counters stay the same set from one learner to the next. [color] is the value
+ * the status is configured with and is left for the caller to resolve.
+ */
+data class AttendanceStatusCount(
+    val key: String,
+    val code: String,
+    val label: String,
+    val color: String?,
+    val count: Int,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCounts.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCounts.kt
@@ -41,14 +41,21 @@ fun attendanceStatusCounts(
     if (configured.isEmpty() || !derivePresent) return configured
 
     val configuredCodes = configured.mapTo(mutableSetOf()) { it.code }
-    // The option the configuration leaves out is the present one, so it names the counter
-    // when the option set has it.
-    val leftoverOption = optionLabels.entries.firstOrNull { it.key !in configuredCodes }
+    // Named after the present option of the option set, matched on its own code or name.
+    // Picking whichever option the configuration happens to leave out is not enough: an
+    // option set commonly carries more of them, and the first one is rarely present.
+    val presentOption = optionLabels.entries.firstOrNull { (code, label) ->
+        code !in configuredCodes &&
+            (
+                code.equals(PRESENT_STATUS_KEY, ignoreCase = true) ||
+                    label.equals(PRESENT_STATUS_KEY, ignoreCase = true)
+                )
+    }
 
     val present = AttendanceStatusCount(
         key = PRESENT_STATUS_KEY,
-        code = leftoverOption?.key ?: PRESENT_STATUS_KEY,
-        label = leftoverOption?.value ?: fallbackPresentLabel,
+        code = presentOption?.key ?: PRESENT_STATUS_KEY,
+        label = presentOption?.value ?: fallbackPresentLabel,
         color = null,
         count = recordedStatusCodes.count { it !in configuredCodes },
     )

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCounts.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCounts.kt
@@ -1,0 +1,57 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import org.saudigitus.semis.core.data.model.app_config.StatusOption
+
+/** Key the derived present counter carries, so it resolves the configured present color. */
+const val PRESENT_STATUS_KEY = "present"
+
+/**
+ * Counts the attendance of a learner against the configured statuses.
+ *
+ * Each configured status is counted from the records, reporting zero when the learner has
+ * no day of it. With the attendance status flow on the configuration drops the present
+ * option — only absence, late and the like are configured — so present is what the records
+ * leave over: the days whose status is none of the configured ones.
+ *
+ * Nothing is counted when the program configures no status at all, since there would be
+ * no statuses to report against.
+ */
+fun attendanceStatusCounts(
+    statusOptions: List<StatusOption>,
+    optionLabels: Map<String, String>,
+    recordedStatusCodes: List<String>,
+    derivePresent: Boolean,
+    fallbackPresentLabel: String = "Present",
+): List<AttendanceStatusCount> {
+    val counts = recordedStatusCodes.groupingBy { it }.eachCount()
+    val configured = statusOptions.mapNotNull { option ->
+        val code = option.code?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+
+        AttendanceStatusCount(
+            key = option.key.orEmpty(),
+            code = code,
+            label = optionLabels[code]
+                ?: option.key?.takeIf { it.isNotBlank() }
+                ?: code,
+            color = option.color,
+            count = counts[code] ?: 0,
+        )
+    }
+
+    if (configured.isEmpty() || !derivePresent) return configured
+
+    val configuredCodes = configured.mapTo(mutableSetOf()) { it.code }
+    // The option the configuration leaves out is the present one, so it names the counter
+    // when the option set has it.
+    val leftoverOption = optionLabels.entries.firstOrNull { it.key !in configuredCodes }
+
+    val present = AttendanceStatusCount(
+        key = PRESENT_STATUS_KEY,
+        code = leftoverOption?.key ?: PRESENT_STATUS_KEY,
+        label = leftoverOption?.value ?: fallbackPresentLabel,
+        color = null,
+        count = recordedStatusCodes.count { it !in configuredCodes },
+    )
+
+    return listOf(present) + configured
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/ProfileAttribute.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/ProfileAttribute.kt
@@ -1,0 +1,9 @@
+package org.saudigitus.semis.core.data.model.profile
+
+/**
+ * A labelled value of a learner profile, be it a tracked entity attribute or a data value.
+ */
+data class ProfileAttribute(
+    val label: String,
+    val value: String?,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/ProfileMark.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/ProfileMark.kt
@@ -1,0 +1,14 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import java.util.Date
+
+/**
+ * A single mark recorded for a learner in a subject.
+ */
+data class ProfileMark(
+    val eventUid: String,
+    val date: Date?,
+    val label: String,
+    val value: Double?,
+    val displayValue: String,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/SocioEconomicRecord.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/SocioEconomicRecord.kt
@@ -1,0 +1,14 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import java.util.Date
+
+/**
+ * One socio-economic record captured for a learner, with the data values it holds.
+ */
+data class SocioEconomicRecord(
+    val eventUid: String,
+    val occurredAt: Date?,
+    val orgUnitName: String,
+    val isActive: Boolean,
+    val details: List<ProfileAttribute>,
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/SubjectPerformance.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/SubjectPerformance.kt
@@ -1,0 +1,15 @@
+package org.saudigitus.semis.core.data.model.profile
+
+/**
+ * Marks a learner collected for one subject, with the average they add up to.
+ */
+data class SubjectPerformance(
+    val programStage: String,
+    val subject: String,
+    val marks: List<ProfileMark> = emptyList(),
+) {
+    val average: Double? = marks
+        .mapNotNull { it.value }
+        .takeIf { it.isNotEmpty() }
+        ?.average()
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/TeiProfile.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/profile/TeiProfile.kt
@@ -1,0 +1,14 @@
+package org.saudigitus.semis.core.data.model.profile
+
+/**
+ * Everything the learner dashboard shows, gathered for the filters the home screen is on.
+ */
+data class TeiProfile(
+    val teiUid: String,
+    val name: String,
+    val systemId: String,
+    val identity: List<ProfileAttribute> = emptyList(),
+    val socioEconomics: List<SocioEconomicRecord> = emptyList(),
+    val attendance: AttendanceHistory = AttendanceHistory(),
+    val performance: List<SubjectPerformance> = emptyList(),
+)

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiProfileRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiProfileRepository.kt
@@ -1,0 +1,19 @@
+package org.saudigitus.semis.core.data.repository
+
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+
+interface TeiProfileRepository {
+
+    /**
+     * Gathers the dashboard of one learner.
+     *
+     * [academicYear] is the label or code selected on the home screen and scopes the
+     * attendance and performance history to that year; when it cannot be resolved against
+     * the school calendar the whole history is kept rather than nothing.
+     */
+    suspend fun getProfile(
+        teiUid: String,
+        program: String,
+        academicYear: String?,
+    ): TeiProfile?
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiProfileRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiProfileRepositoryImpl.kt
@@ -1,0 +1,262 @@
+package org.saudigitus.semis.core.data.repository
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.event.Event
+import org.hisp.dhis.android.core.event.EventStatus
+import org.saudigitus.semis.core.data.model.app_config.SEMISConfigItem
+import org.saudigitus.semis.core.data.model.app_config.isEnabledAndConfigured
+import org.saudigitus.semis.core.data.model.profile.AttendanceHistory
+import org.saudigitus.semis.core.data.model.profile.AttendanceRecord
+import org.saudigitus.semis.core.data.model.profile.attendanceStatusCounts
+import org.saudigitus.semis.core.data.model.profile.ProfileAttribute
+import org.saudigitus.semis.core.data.model.profile.ProfileMark
+import org.saudigitus.semis.core.data.model.profile.SocioEconomicRecord
+import org.saudigitus.semis.core.data.model.profile.SubjectPerformance
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+import org.saudigitus.semis.core.data.model.transfer.learnerIdentity
+import org.saudigitus.semis.core.data.utils.Transformations
+import java.util.Date
+import javax.inject.Inject
+
+class TeiProfileRepositoryImpl @Inject constructor(
+    private val d2: D2,
+    private val appConfigRepository: AppConfigRepository,
+    private val transformations: Transformations,
+) : TeiProfileRepository {
+
+    override suspend fun getProfile(
+        teiUid: String,
+        program: String,
+        academicYear: String?,
+    ): TeiProfile? = withContext(Dispatchers.IO) {
+        val tei = d2.trackedEntityModule().trackedEntityInstances()
+            .byUid().eq(teiUid)
+            .withTrackedEntityAttributeValues()
+            .one()
+            .blockingGet()
+            ?: return@withContext null
+
+        val enrollment = d2.enrollmentModule().enrollments()
+            .byTrackedEntityInstance().eq(teiUid)
+            .byProgram().eq(program)
+            .byDeleted().isFalse
+            .one()
+            .blockingGet()
+        val learner = transformations.transform(tei, program, enrollment)
+        val identity = learner.learnerIdentity()
+        val config = appConfigRepository.getAppConfig(program)
+        val range = academicYearRange(academicYear)
+
+        TeiProfile(
+            teiUid = teiUid,
+            name = identity.name,
+            systemId = identity.firstAttributeValue,
+            identity = learner.attributeValues.map { (label, attribute) ->
+                ProfileAttribute(label = label, value = attribute.value())
+            },
+            socioEconomics = socioEconomicRecords(teiUid, program, config),
+            attendance = attendanceHistory(teiUid, program, config, range),
+            performance = subjectPerformance(teiUid, program, config, range),
+        )
+    }
+
+    private fun socioEconomicRecords(
+        teiUid: String,
+        program: String,
+        config: SEMISConfigItem?,
+    ): List<SocioEconomicRecord> {
+        val programStage = config?.socioEconomics?.programStage
+            ?.takeIf { it.isNotBlank() }
+            ?: return emptyList()
+        val labels = dataElementLabels(programStage)
+
+        return events(teiUid, program, programStage)
+            .map { event ->
+                SocioEconomicRecord(
+                    eventUid = event.uid(),
+                    occurredAt = event.eventDate(),
+                    orgUnitName = orgUnitName(event.organisationUnit()),
+                    isActive = event.status() == EventStatus.ACTIVE,
+                    details = event.trackedEntityDataValues().orEmpty().map { value ->
+                        ProfileAttribute(
+                            label = labels[value.dataElement()] ?: value.dataElement().orEmpty(),
+                            value = value.value(),
+                        )
+                    },
+                )
+            }
+            .sortedByDescending { it.occurredAt }
+    }
+
+    private fun attendanceHistory(
+        teiUid: String,
+        program: String,
+        config: SEMISConfigItem?,
+        range: ClosedRange<Date>?,
+    ): AttendanceHistory {
+        val attendance = config?.attendance ?: return AttendanceHistory()
+        val programStage = attendance.programStage?.takeIf { it.isNotBlank() }
+            ?: return AttendanceHistory()
+        val statusDataElement = attendance.status.orEmpty()
+        val reasonDataElement = attendance.absenceReason.orEmpty()
+        val statusLabels = optionLabels(statusDataElement)
+        val reasonLabels = optionLabels(reasonDataElement)
+
+        val records = events(teiUid, program, programStage)
+            .filter { it.eventDate().inRange(range) }
+            .mapNotNull { event ->
+                val statusCode = event.dataValue(statusDataElement)
+                    ?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+                val reasonCode = event.dataValue(reasonDataElement)?.takeIf { it.isNotBlank() }
+
+                AttendanceRecord(
+                    eventUid = event.uid(),
+                    date = event.eventDate(),
+                    statusCode = statusCode,
+                    statusLabel = statusLabels[statusCode] ?: statusCode,
+                    absenceReason = reasonCode?.let { reasonLabels[it] ?: it },
+                )
+            }
+            .sortedByDescending { it.date }
+
+        return AttendanceHistory(
+            records = records,
+            statusCounts = attendanceStatusCounts(
+                statusOptions = attendance.statusOptions?.filterNotNull().orEmpty(),
+                optionLabels = statusLabels,
+                recordedStatusCodes = records.map { it.statusCode },
+                derivePresent = attendance.attendanceStatus.isEnabledAndConfigured(),
+            ),
+        )
+    }
+
+    private fun subjectPerformance(
+        teiUid: String,
+        program: String,
+        config: SEMISConfigItem?,
+        range: ClosedRange<Date>?,
+    ): List<SubjectPerformance> {
+        val performance = config?.performance?.takeIf { it.enabled == true } ?: return emptyList()
+
+        return performance.programStages
+            ?.mapNotNull { stage -> stage?.programStage?.takeIf { it.isNotBlank() } }
+            .orEmpty()
+            .map { programStage ->
+                val labels = dataElementLabels(programStage)
+                val marks = events(teiUid, program, programStage)
+                    .filter { it.eventDate().inRange(range) }
+                    .flatMap { event ->
+                        event.trackedEntityDataValues().orEmpty().mapNotNull { value ->
+                            val raw = value.value()?.takeIf { it.isNotBlank() }
+                                ?: return@mapNotNull null
+
+                            ProfileMark(
+                                eventUid = event.uid(),
+                                date = event.eventDate(),
+                                label = labels[value.dataElement()]
+                                    ?: value.dataElement().orEmpty(),
+                                value = raw.toDoubleOrNull(),
+                                displayValue = raw,
+                            )
+                        }
+                    }
+                    .sortedByDescending { it.date }
+
+                SubjectPerformance(
+                    programStage = programStage,
+                    subject = programStageName(programStage),
+                    marks = marks,
+                )
+            }
+    }
+
+    private fun events(teiUid: String, program: String, programStage: String): List<Event> =
+        d2.eventModule().events()
+            .byTrackedEntityInstanceUids(listOf(teiUid))
+            .byProgramUid().eq(program)
+            .byProgramStageUid().eq(programStage)
+            .byDeleted().isFalse
+            .withTrackedEntityDataValues()
+            .blockingGet()
+
+    private fun dataElementLabels(programStage: String): Map<String, String> =
+        d2.programModule().programStageDataElements()
+            .byProgramStage().eq(programStage)
+            .blockingGet()
+            .mapNotNull { it.dataElement()?.uid() }
+            .distinct()
+            .mapNotNull { uid ->
+                d2.dataElementModule().dataElements().uid(uid).blockingGet()?.let { element ->
+                    uid to (element.displayFormName() ?: element.displayName() ?: uid)
+                }
+            }
+            .toMap()
+
+    /** Display names of the options of [dataElement], keyed by option code. */
+    private fun optionLabels(dataElement: String): Map<String, String> {
+        if (dataElement.isBlank()) return emptyMap()
+
+        val optionSet = d2.dataElementModule().dataElements()
+            .uid(dataElement)
+            .blockingGet()
+            ?.optionSetUid()
+            ?: return emptyMap()
+
+        return d2.optionModule().options()
+            .byOptionSetUid().eq(optionSet)
+            .blockingGet()
+            .mapNotNull { option ->
+                option.code()?.let { code -> code to (option.displayName() ?: code) }
+            }
+            .toMap()
+    }
+
+    private fun programStageName(programStage: String): String =
+        d2.programModule().programStages()
+            .uid(programStage)
+            .blockingGet()
+            ?.displayName()
+            .orEmpty()
+            .ifBlank { programStage }
+
+    private fun orgUnitName(orgUnit: String?): String =
+        orgUnit?.let {
+            d2.organisationUnitModule().organisationUnits().uid(it).blockingGet()?.displayName()
+        }.orEmpty()
+
+    /**
+     * Start and end of the selected academic year, taken from the school calendar. Returns
+     * null when the year cannot be resolved, which keeps the whole history visible instead
+     * of silently emptying the dashboard.
+     */
+    private suspend fun academicYearRange(academicYear: String?): ClosedRange<Date>? {
+        val year = academicYear?.takeIf { it.isNotBlank() } ?: return null
+        val configured = appConfigRepository.getSchoolCalendar()?.schoolCalendar
+            ?.filterNotNull()
+            ?.firstOrNull { entry ->
+                entry.academicYear?.let { it.label == year || it.code == year } == true
+            }
+            ?.academicYear
+            ?: return null
+        val start = parseDate(configured.startDate) ?: return null
+        val end = parseDate(configured.endDate) ?: return null
+
+        return start..end
+    }
+
+    private fun parseDate(value: String?): Date? = value
+        ?.takeIf { it.isNotBlank() }
+        ?.let { date -> runCatching { java.sql.Date.valueOf(date) as Date }.getOrNull() }
+
+    private fun Date?.inRange(range: ClosedRange<Date>?): Boolean = when {
+        range == null -> true
+        this == null -> false
+        else -> this in range
+    }
+
+    private fun Event.dataValue(dataElement: String): String? =
+        trackedEntityDataValues()?.find { it.dataElement() == dataElement }?.value()
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiTransferRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/TeiTransferRepositoryImpl.kt
@@ -8,8 +8,8 @@ import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.core.data.R
 import org.saudigitus.semis.core.data.model.app_config.Transfer
-import org.saudigitus.semis.core.data.model.app_config.isIncomingEnabledAndConfigured
 import org.saudigitus.semis.core.data.model.app_config.approvedStatusCode
+import org.saudigitus.semis.core.data.model.app_config.isIncomingEnabledAndConfigured
 import org.saudigitus.semis.core.data.model.app_config.pendingStatusCode
 import org.saudigitus.semis.core.data.model.app_config.rejectedStatusCode
 import org.saudigitus.semis.core.data.model.transfer.IncomingTeiTransfer
@@ -120,8 +120,6 @@ class TeiTransferRepositoryImpl @Inject constructor(
             ?.takeIf { it.isIncomingEnabledAndConfigured() }
             ?: return@withContext emptyList()
 
-        // The transfer event is created at the destination school, so an outgoing request
-        // is recognised by its origin data value rather than by the event organisation unit.
         d2.eventModule().events()
             .byProgramUid().eq(program)
             .byProgramStageUid().eq(transfer.programStage.orEmpty())
@@ -174,8 +172,6 @@ class TeiTransferRepositoryImpl @Inject constructor(
                 ?: error(resourceManager.getString(R.string.transfer_rejected_status_missing))
         }
 
-        // A refused transfer has to hand the learner back before the request is closed,
-        // otherwise they would stay enrolled at the school that turned them down.
         if (decision == TransferDecision.REJECT) {
             returnLearnerToOrigin(event, program, transfer)
         }
@@ -346,8 +342,6 @@ class TeiTransferRepositoryImpl @Inject constructor(
             destinationOrgUnit = destinationOrgUnit,
             destinationSchoolName = destinationSchoolName,
             statusCode = statusCode,
-            // Approving a transfer only completes the event, so a request stops being
-            // pending either when the status value changes or when the event is closed.
             isPending = event.status() == EventStatus.ACTIVE &&
                 statusCode == transfer.pendingStatusCode(),
             effectiveDate = event.eventDate() ?: java.util.Date(),

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCountsTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCountsTest.kt
@@ -147,4 +147,34 @@ class AttendanceStatusCountsTest {
 
         assertEquals("#E57373", counts.single().color)
     }
+
+    @Test
+    fun `another unconfigured option does not take over the present counter`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = listOf(option("ABSENT", "absent")),
+            optionLabels = mapOf(
+                "LATE" to "Late",
+                "EXCUSED" to "Excused",
+                "PRESENT" to "Present",
+            ),
+            recordedStatusCodes = listOf("PRESENT", "LATE", "ABSENT"),
+            derivePresent = true,
+        )
+
+        assertEquals("Present", counts.first().label)
+        assertEquals(2, counts.first().count)
+    }
+
+    @Test
+    fun `the present option is recognised by its name when its code is opaque`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = listOf(option("2", "absent")),
+            optionLabels = mapOf("3" to "Late", "1" to "Present"),
+            recordedStatusCodes = listOf("1"),
+            derivePresent = true,
+        )
+
+        assertEquals("Present", counts.first().label)
+        assertEquals("1", counts.first().code)
+    }
 }

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCountsTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/AttendanceStatusCountsTest.kt
@@ -1,0 +1,150 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.data.model.app_config.StatusOption
+
+class AttendanceStatusCountsTest {
+
+    private fun option(code: String, key: String, color: String? = null) = StatusOption(
+        code = code,
+        color = color,
+        configKey = null,
+        icon = null,
+        key = key,
+        totalSummary = null,
+    )
+
+    /** Configuration used while the attendance status flow is on: present is left out. */
+    private val statusFlowOptions = listOf(
+        option("ABSENT", "absent"),
+        option("LATE", "late"),
+    )
+
+    /** Configuration used while the flow is off: every status is configured. */
+    private val plainOptions = listOf(
+        option("PRESENT", "present"),
+        option("ABSENT", "absent"),
+        option("LATE", "late"),
+    )
+
+    private val labels = mapOf(
+        "PRESENT" to "Present",
+        "ABSENT" to "Absent",
+        "LATE" to "Late",
+    )
+
+    @Test
+    fun `with the status flow on the days no configured status claims are present`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = labels,
+            recordedStatusCodes = listOf("PRESENT", "PRESENT", "PRESENT", "ABSENT", "LATE"),
+            derivePresent = true,
+        )
+
+        assertEquals(listOf("Present", "Absent", "Late"), counts.map { it.label })
+        assertEquals(listOf(3, 1, 1), counts.map { it.count })
+    }
+
+    @Test
+    fun `the derived present counter leads the configured statuses`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = labels,
+            recordedStatusCodes = listOf("ABSENT"),
+            derivePresent = true,
+        )
+
+        assertEquals("Present", counts.first().label)
+        assertEquals(PRESENT_STATUS_KEY, counts.first().key)
+    }
+
+    @Test
+    fun `an unconfigured status code counts towards present`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = labels,
+            recordedStatusCodes = listOf("PRESENT", "SOMETHING_ELSE", "ABSENT"),
+            derivePresent = true,
+        ).associateBy { it.label }
+
+        assertEquals(2, counts.getValue("Present").count)
+        assertEquals(1, counts.getValue("Absent").count)
+    }
+
+    @Test
+    fun `present reports zero when every recorded day carries a configured status`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = labels,
+            recordedStatusCodes = listOf("ABSENT", "LATE", "LATE"),
+            derivePresent = true,
+        )
+
+        assertEquals(listOf(0, 1, 2), counts.map { it.count })
+    }
+
+    @Test
+    fun `a learner without attendance still reports every status at zero`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = labels,
+            recordedStatusCodes = emptyList(),
+            derivePresent = true,
+        )
+
+        assertEquals(listOf("Present", "Absent", "Late"), counts.map { it.label })
+        assertEquals(listOf(0, 0, 0), counts.map { it.count })
+    }
+
+    @Test
+    fun `without the status flow present is counted from its own configured option`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = plainOptions,
+            optionLabels = labels,
+            recordedStatusCodes = listOf("PRESENT", "PRESENT", "ABSENT"),
+            derivePresent = false,
+        )
+
+        assertEquals(listOf("Present", "Absent", "Late"), counts.map { it.label })
+        assertEquals(listOf(2, 1, 0), counts.map { it.count })
+    }
+
+    @Test
+    fun `nothing is counted when the program configures no status`() {
+        assertEquals(
+            emptyList<AttendanceStatusCount>(),
+            attendanceStatusCounts(
+                statusOptions = emptyList(),
+                optionLabels = labels,
+                recordedStatusCodes = listOf("ABSENT"),
+                derivePresent = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `the present counter falls back to a label when the option set has no spare option`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = statusFlowOptions,
+            optionLabels = mapOf("ABSENT" to "Absent", "LATE" to "Late"),
+            recordedStatusCodes = listOf("ABSENT"),
+            derivePresent = true,
+        )
+
+        assertEquals("Present", counts.first().label)
+    }
+
+    @Test
+    fun `a configured status keeps the color it was configured with`() {
+        val counts = attendanceStatusCounts(
+            statusOptions = listOf(option("ABSENT", "absent", color = "#E57373")),
+            optionLabels = labels,
+            recordedStatusCodes = emptyList(),
+            derivePresent = false,
+        )
+
+        assertEquals("#E57373", counts.single().color)
+    }
+}

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/SubjectPerformanceTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/profile/SubjectPerformanceTest.kt
@@ -1,0 +1,42 @@
+package org.saudigitus.semis.core.data.model.profile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubjectPerformanceTest {
+
+    private fun mark(value: String) = ProfileMark(
+        eventUid = "event-$value",
+        date = null,
+        label = "Term",
+        value = value.toDoubleOrNull(),
+        displayValue = value,
+    )
+
+    private fun subject(vararg values: String) = SubjectPerformance(
+        programStage = "stage",
+        subject = "History",
+        marks = values.map(::mark),
+    )
+
+    @Test
+    fun `the average of a subject is the mean of its marks`() {
+        assertEquals(12.0, subject("10", "12", "14").average!!, 0.001)
+    }
+
+    @Test
+    fun `a subject without marks has no average`() {
+        assertNull(subject().average)
+    }
+
+    @Test
+    fun `marks that are not numbers are left out of the average`() {
+        assertEquals(10.0, subject("10", "absent").average!!, 0.001)
+    }
+
+    @Test
+    fun `a subject whose marks are all unreadable has no average`() {
+        assertNull(subject("absent", "n/a").average)
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/cards/DetailCard.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/cards/DetailCard.kt
@@ -1,0 +1,116 @@
+package org.saudigitus.semis.core.designsystem.components.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.saudigitus.semis.core.designsystem.R
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+import org.saudigitus.semis.core.designsystem.theme.semisSoftShadow
+import org.saudigitus.semis.core.designsystem.theme.surfaceTone
+
+/**
+ * Titled card grouping a set of read-only details, with an optional accent icon and a
+ * trailing slot for a status next to the title.
+ */
+@Composable
+fun DetailCard(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    imageVector: ImageVector? = null,
+    accent: Color = SemisAccent.Blue,
+    containerColor: Color = SemisPalette.CardSurface,
+    trailing: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val shape = RoundedCornerShape(16.dp)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .semisSoftShadow(shape)
+            .background(color = containerColor, shape = shape)
+            .padding(horizontal = 14.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            imageVector?.let { icon ->
+                Box(
+                    modifier = Modifier
+                        .size(30.dp)
+                        .background(color = accent.surfaceTone(alpha = .12f), shape = CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(1.dp),
+            ) {
+                Text(
+                    text = title,
+                    color = SemisPalette.TextPrimary,
+                    fontSize = 14.sp,
+                    lineHeight = 18.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontFamily = FontFamily(Font(R.font.rubik_medium)),
+                )
+                subtitle?.takeIf { it.isNotBlank() }?.let { value ->
+                    Text(
+                        text = value,
+                        color = SemisPalette.TextMuted,
+                        fontSize = 11.5.sp,
+                        lineHeight = 15.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontFamily = FontFamily(Font(R.font.rubik_regular)),
+                    )
+                }
+            }
+
+            trailing?.invoke()
+        }
+
+        HorizontalDivider(color = SemisPalette.CardBorder)
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            content = content,
+        )
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/filters/FilterDetailsInfoCard.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/filters/FilterDetailsInfoCard.kt
@@ -1,4 +1,4 @@
-package org.saudigitus.semis.attendance.ui.components
+package org.saudigitus.semis.core.designsystem.components.filters
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -9,31 +9,38 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.saudigitus.semis.core.designsystem.R
 import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
-import org.saudigitus.semis.core.designsystem.components.filters.FilterInfoCard
-import org.saudigitus.semis.core.designsystem.components.filters.FilterInfoItem
 import org.saudigitus.semis.core.designsystem.theme.SemisPalette
 
 /**
- * Filter context the attendance list is scoped to, laid over the screen header on the
- * same translucent surface as the header actions. Grade and class are only rendered when
- * the program configuration provides them.
+ * The selection a screen is scoped to — academic year, school, grade and class — rendered
+ * over a colored header on the same translucent surface as the header actions.
+ *
+ * Grade and class are dropped when the program configuration does not provide them, so the
+ * remaining entries widen instead of leaving gaps.
  */
 @Composable
-internal fun AttendanceFilterInfo(
+fun FilterDetailsInfoCard(
     state: FilterDetailsState,
     modifier: Modifier = Modifier,
+    containerColor: Color = SemisPalette.HeaderSurface,
+    accentColor: Color = Color.White,
+    iconContainerColor: Color = SemisPalette.HeaderSurface,
+    labelColor: Color = SemisPalette.OnHeaderSecondary,
+    valueColor: Color = SemisPalette.OnHeaderPrimary,
+    elevation: Dp = 0.dp,
 ) {
     FilterInfoCard(
         modifier = modifier,
-        containerColor = SemisPalette.HeaderSurface,
-        accentColor = Color.White,
-        iconContainerColor = SemisPalette.HeaderSurface,
-        labelColor = SemisPalette.OnHeaderSecondary,
-        valueColor = SemisPalette.OnHeaderPrimary,
-        elevation = 0.dp,
+        containerColor = containerColor,
+        accentColor = accentColor,
+        iconContainerColor = iconContainerColor,
+        labelColor = labelColor,
+        valueColor = valueColor,
+        elevation = elevation,
         items = listOf(
             FilterInfoItem(
                 label = stringResource(R.string.academic_year),

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/rows/LabelValueRow.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/rows/LabelValueRow.kt
@@ -1,0 +1,65 @@
+package org.saudigitus.semis.core.designsystem.components.rows
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.saudigitus.semis.core.designsystem.R
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+
+/**
+ * A labelled value: the label on the left, the value aligned to the right.
+ *
+ * A missing value is stated rather than left blank, so a reader can tell an empty field
+ * apart from one that was never captured.
+ */
+@Composable
+fun LabelValueRow(
+    label: String,
+    value: String?,
+    modifier: Modifier = Modifier,
+    emptyValueLabel: String = stringResource(R.string.not_recorded),
+) {
+    val recorded = value?.takeIf { it.isNotBlank() }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.weight(1f),
+            color = SemisPalette.TextSecondary,
+            fontSize = 12.5.sp,
+            lineHeight = 17.sp,
+            fontFamily = FontFamily(Font(R.font.rubik_regular)),
+        )
+        Text(
+            text = recorded ?: emptyValueLabel,
+            modifier = Modifier.weight(1f),
+            color = if (recorded != null) {
+                SemisPalette.TextPrimary
+            } else {
+                SemisPalette.TextMuted
+            },
+            fontSize = 12.5.sp,
+            lineHeight = 17.sp,
+            textAlign = TextAlign.End,
+            fontStyle = if (recorded == null) FontStyle.Italic else FontStyle.Normal,
+            fontFamily = FontFamily(
+                Font(if (recorded != null) R.font.rubik_medium else R.font.rubik_regular),
+            ),
+        )
+    }
+}

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/tabs/SegmentedTabItem.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/tabs/SegmentedTabItem.kt
@@ -1,0 +1,13 @@
+package org.saudigitus.semis.core.designsystem.components.tabs
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * One choice of a [SegmentedTabRow].
+ */
+@Immutable
+data class SegmentedTabItem(
+    val id: String,
+    val label: String,
+    val badge: String? = null,
+)

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/tabs/SegmentedTabRow.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/tabs/SegmentedTabRow.kt
@@ -1,0 +1,70 @@
+package org.saudigitus.semis.core.designsystem.components.tabs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.saudigitus.semis.core.designsystem.R
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+import org.saudigitus.semis.core.designsystem.theme.surfaceTone
+
+/**
+ * Horizontally scrollable pill tabs. Scrolls rather than squeezing, so a label is never
+ * cut to fit more tabs on screen.
+ */
+@Composable
+fun SegmentedTabRow(
+    tabs: List<SegmentedTabItem>,
+    selectedId: String,
+    modifier: Modifier = Modifier,
+    accent: Color = SemisAccent.Blue,
+    onSelect: (SegmentedTabItem) -> Unit,
+) {
+    if (tabs.isEmpty()) return
+
+    Row(
+        modifier = modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        tabs.forEach { tab ->
+            val selected = tab.id == selectedId
+
+            Text(
+                text = tab.badge?.let { badge -> "${tab.label} ($badge)" } ?: tab.label,
+                modifier = Modifier
+                    .background(
+                        color = if (selected) accent else accent.surfaceTone(alpha = .08f),
+                        shape = RoundedCornerShape(100.dp),
+                    )
+                    .clickable(
+                        enabled = !selected,
+                        role = Role.Tab,
+                        onClick = { onSelect(tab) },
+                    )
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                color = if (selected) Color.White else SemisPalette.TextSecondary,
+                fontSize = 12.5.sp,
+                maxLines = 1,
+                fontFamily = FontFamily(
+                    Font(if (selected) R.font.rubik_medium else R.font.rubik_regular),
+                ),
+            )
+        }
+    }
+}

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="take_attendance">Take Attendance</string>
     <string name="complete_attendance">Complete Attendance</string>
     <string name="update_attendance">Update Attendance</string>
+    <string name="not_recorded">Not recorded</string>
     <string name="reset_attendance_form">Reset attendance</string>
     <string name="app_not_properly_config">App not configured properly. Please contact System Administrator</string>
     <string name="attendance_saved">Attendance saved successfully</string>

--- a/semis/enrollment/build.gradle.kts
+++ b/semis/enrollment/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(project(":commons"))
     implementation(project(":semis:core:data"))
     implementation(project(":semis:core:designsystem"))
+    implementation(project(":semis:core:utils"))
     implementation(project(":semis-core:data"))
     implementation(project(":semis-core:form"))
     implementation(project(":semis-core:navigation"))

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/EnrollmentScreen.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/EnrollmentScreen.kt
@@ -35,6 +35,7 @@ fun EnrollmentScreen(
     onBack: () -> Unit,
     onSync: () -> Unit,
     onNewEnrollment: () -> Unit,
+    onTeiClick: (teiUid: String) -> Unit = {},
 ) {
     TopAppBarScaffold(
         toolbarHeaders = ToolbarHeaders(title = programName),
@@ -79,6 +80,7 @@ fun EnrollmentScreen(
                             tei = student,
                             modifier = Modifier.testTag("ENROLLMENT_TEI_ITEM"),
                             maxAdditionalInfo = 0,
+                            onClick = { onTeiClick(student.tei.uid()) },
                         )
                     }
                 }

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileEvent.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileEvent.kt
@@ -1,0 +1,6 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+sealed interface StudentProfileEvent {
+    data object OnBack : StudentProfileEvent
+    data class SelectTab(val tab: StudentProfileTab) : StudentProfileEvent
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileScreen.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileScreen.kt
@@ -1,0 +1,131 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.saudigitus.semis.core.designsystem.components.notice.InlineNotice
+import org.saudigitus.semis.core.designsystem.components.tabs.SegmentedTabItem
+import org.saudigitus.semis.core.designsystem.components.tabs.SegmentedTabRow
+import org.saudigitus.semis.core.designsystem.templates.RoundedHeaderScaffold
+import org.saudigitus.semis.core.designsystem.theme.dark_warning
+import org.saudigitus.semis.enrollment.R
+import org.saudigitus.semis.enrollment.ui.profile.components.StudentAttendanceSection
+import org.saudigitus.semis.enrollment.ui.profile.components.StudentDetailsSection
+import org.saudigitus.semis.enrollment.ui.profile.components.StudentPerformanceSection
+import org.saudigitus.semis.enrollment.ui.profile.components.StudentProfileHeader
+
+/**
+ * Dashboard of one learner: who they are, then the socio-economic, attendance and
+ * performance data captured for them under the selection made on the home screen.
+ */
+@Composable
+fun StudentProfileScreen(
+    state: StudentProfileUiState,
+    onEvent: (StudentProfileEvent) -> Unit,
+) {
+    val profile = state.profile
+
+    RoundedHeaderScaffold(
+        header = {
+            StudentProfileHeader(
+                name = profile?.name.orEmpty()
+                    .ifBlank { stringResource(R.string.profile_unknown_learner) },
+                systemId = profile?.systemId.orEmpty(),
+                tiles = studentProfileTiles(
+                    recordedDaysLabel = stringResource(R.string.profile_recorded),
+                    profile = profile,
+                ),
+                filterDetailsState = state.filterDetailsState,
+                onNavigateBack = { onEvent(StudentProfileEvent.OnBack) },
+            )
+        },
+    ) {
+        when {
+            state.isLoading -> Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) { CircularProgressIndicator() }
+
+            profile == null -> InlineNotice(
+                text = state.errorMessage
+                    ?: stringResource(R.string.profile_not_found),
+                imageVector = Icons.Default.Warning,
+                tone = dark_warning,
+                modifier = Modifier.padding(16.dp),
+            )
+
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = 12.dp,
+                    end = 16.dp,
+                    bottom = 24.dp,
+                ),
+            ) {
+                item {
+                    SegmentedTabRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 12.dp),
+                        tabs = profileTabs(state),
+                        selectedId = state.selectedTab.name,
+                        onSelect = { tab ->
+                            onEvent(
+                                StudentProfileEvent.SelectTab(
+                                    StudentProfileTab.valueOf(tab.id),
+                                ),
+                            )
+                        },
+                    )
+                }
+
+                item {
+                    when (state.selectedTab) {
+                        StudentProfileTab.DETAILS -> StudentDetailsSection(profile = profile)
+                        StudentProfileTab.ATTENDANCE -> StudentAttendanceSection(
+                            history = profile.attendance,
+                        )
+
+                        StudentProfileTab.PERFORMANCE -> StudentPerformanceSection(
+                            subjects = state.scoredSubjects,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun profileTabs(state: StudentProfileUiState): List<SegmentedTabItem> = listOf(
+    SegmentedTabItem(
+        id = StudentProfileTab.DETAILS.name,
+        label = stringResource(R.string.profile_tab_details),
+    ),
+    SegmentedTabItem(
+        id = StudentProfileTab.ATTENDANCE.name,
+        label = stringResource(R.string.profile_tab_attendance),
+        badge = state.profile?.attendance?.recordedDays
+            ?.takeIf { it > 0 }
+            ?.toString(),
+    ),
+    SegmentedTabItem(
+        id = StudentProfileTab.PERFORMANCE.name,
+        label = stringResource(R.string.profile_tab_performance),
+        badge = state.scoredSubjects.size.takeIf { it > 0 }?.toString(),
+    ),
+)

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTab.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTab.kt
@@ -1,0 +1,10 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+/**
+ * Sections of the learner dashboard.
+ */
+enum class StudentProfileTab {
+    DETAILS,
+    ATTENDANCE,
+    PERFORMANCE,
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTiles.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTiles.kt
@@ -1,0 +1,48 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+import org.saudigitus.semis.core.designsystem.components.stats.StatTileModel
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+import org.saudigitus.semis.core.designsystem.theme.readableContentColor
+import org.saudigitus.semis.core.designsystem.utils.UiDefaults
+
+/**
+ * Header counters of the dashboard: how many days were recorded, followed by one tile per
+ * configured attendance status painted with the color that status is configured with.
+ *
+ * A status the learner holds no day of still reports zero, so the counters read the same
+ * from one learner to the next. They are dropped altogether only when the program
+ * configures no attendance status to count.
+ */
+internal fun studentProfileTiles(
+    recordedDaysLabel: String,
+    profile: TeiProfile?,
+): List<StatTileModel> {
+    val attendance = profile?.attendance ?: return emptyList()
+
+    if (attendance.statusCounts.isEmpty()) return emptyList()
+
+    val recordedTile = StatTileModel(
+        id = "recorded",
+        label = recordedDaysLabel,
+        value = attendance.recordedDays,
+        containerColor = SemisPalette.HeaderBlueAccent,
+    )
+
+    val statusTiles = attendance.statusCounts.map { status ->
+        val statusColor = UiDefaults.getAttendanceStatusColor(
+            status.key.ifBlank { status.code },
+            status.color.orEmpty(),
+        )
+
+        StatTileModel(
+            id = status.code,
+            label = status.label,
+            value = status.count,
+            containerColor = statusColor,
+            contentColor = statusColor.readableContentColor(),
+        )
+    }
+
+    return listOf(recordedTile) + statusTiles
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileUiState.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileUiState.kt
@@ -1,0 +1,26 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+import androidx.compose.runtime.Immutable
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+
+@Immutable
+data class StudentProfileUiState(
+    val isLoading: Boolean = true,
+    val filterDetailsState: FilterDetailsState = FilterDetailsState(
+        enable = false,
+        enableCounter = false,
+    ),
+    val profile: TeiProfile? = null,
+    val selectedTab: StudentProfileTab = StudentProfileTab.DETAILS,
+    val errorMessage: String? = null,
+) {
+    /** Subjects that hold at least one mark, which are the ones worth a counter. */
+    val scoredSubjects get() = profile?.performance?.filter { it.marks.isNotEmpty() }.orEmpty()
+
+    val hasAttendance get() = profile?.attendance?.records?.isNotEmpty() == true
+
+    val hasPerformance get() = scoredSubjects.isNotEmpty()
+
+    val hasSocioEconomics get() = profile?.socioEconomics?.isNotEmpty() == true
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileViewModel.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileViewModel.kt
@@ -1,0 +1,73 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.saudigitus.semis.core.data.repository.TeiProfileRepository
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import javax.inject.Inject
+
+@HiltViewModel
+class StudentProfileViewModel @Inject constructor(
+    private val repository: TeiProfileRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StudentProfileUiState())
+    val uiState: StateFlow<StudentProfileUiState> = _uiState.asStateFlow()
+
+    private var initialized = false
+
+    /**
+     * Loads the dashboard for [teiUid] under the selection the home screen is on, so the
+     * history shown belongs to the same academic year, school, grade and section.
+     */
+    fun initialize(
+        teiUid: String,
+        program: String,
+        filterDetailsState: FilterDetailsState,
+    ) {
+        if (initialized) return
+        initialized = true
+
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+                filterDetailsState = filterDetailsState.copy(
+                    enable = false,
+                    enableCounter = false,
+                ),
+            )
+        }
+
+        viewModelScope.launch {
+            runCatching {
+                repository.getProfile(
+                    teiUid = teiUid,
+                    program = program,
+                    academicYear = filterDetailsState.academicYear,
+                )
+            }.onSuccess { profile ->
+                _uiState.update { it.copy(isLoading = false, profile = profile) }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(isLoading = false, errorMessage = error.message)
+                }
+            }
+        }
+    }
+
+    fun handleEvent(event: StudentProfileEvent) {
+        when (event) {
+            is StudentProfileEvent.SelectTab -> {
+                _uiState.update { it.copy(selectedTab = event.tab) }
+            }
+
+            StudentProfileEvent.OnBack -> Unit
+        }
+    }
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/ProfileEmptyLine.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/ProfileEmptyLine.kt
@@ -1,0 +1,17 @@
+package org.saudigitus.semis.enrollment.ui.profile.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.saudigitus.semis.core.designsystem.components.text.SectionCaption
+
+/**
+ * Stated absence of data inside a detail card, so an empty section still reads as an
+ * answer rather than a rendering gap.
+ */
+@Composable
+internal fun ProfileEmptyLine(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    SectionCaption(text = text, modifier = modifier)
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentAttendanceSection.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentAttendanceSection.kt
@@ -1,0 +1,75 @@
+package org.saudigitus.semis.enrollment.ui.profile.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.EventAvailable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.saudigitus.semis.core.data.model.profile.AttendanceHistory
+import org.saudigitus.semis.core.designsystem.components.cards.DetailCard
+import org.saudigitus.semis.core.designsystem.components.rows.LabelValueRow
+import org.saudigitus.semis.core.designsystem.components.text.SectionCaption
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
+import org.saudigitus.semis.core.utils.DateHelper
+import org.saudigitus.semis.enrollment.R
+
+/**
+ * Attendance the learner accumulated over the selected academic year: a count per
+ * configured status, then the days themselves, most recent first.
+ */
+@Composable
+internal fun StudentAttendanceSection(
+    history: AttendanceHistory,
+    modifier: Modifier = Modifier,
+    maxRecords: Int = 30,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        DetailCard(
+            title = stringResource(R.string.profile_attendance_summary),
+            subtitle = stringResource(R.string.profile_recorded_days, history.recordedDays),
+            imageVector = Icons.Outlined.EventAvailable,
+            accent = SemisAccent.Teal,
+        ) {
+            if (history.statusCounts.isEmpty()) {
+                ProfileEmptyLine(text = stringResource(R.string.profile_no_attendance))
+            } else {
+                history.statusCounts.forEach { status ->
+                    LabelValueRow(label = status.label, value = "${status.count}")
+                }
+            }
+        }
+
+        if (history.records.isNotEmpty()) {
+            DetailCard(
+                title = stringResource(R.string.profile_attendance_history),
+                imageVector = Icons.Outlined.EventAvailable,
+                accent = SemisAccent.Blue,
+            ) {
+                history.records.take(maxRecords).forEach { record ->
+                    LabelValueRow(
+                        label = record.date?.let { DateHelper.formatDate(it.time) }
+                            ?: stringResource(R.string.profile_unknown_date),
+                        value = listOfNotNull(record.statusLabel, record.absenceReason)
+                            .joinToString(separator = " · "),
+                    )
+                }
+
+                if (history.records.size > maxRecords) {
+                    SectionCaption(
+                        text = stringResource(
+                            R.string.profile_more_records,
+                            history.records.size - maxRecords,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentDetailsSection.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentDetailsSection.kt
@@ -1,0 +1,95 @@
+package org.saudigitus.semis.enrollment.ui.profile.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Badge
+import androidx.compose.material.icons.outlined.Diversity3
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.saudigitus.semis.core.data.model.profile.SocioEconomicRecord
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+import org.saudigitus.semis.core.designsystem.components.cards.DetailCard
+import org.saudigitus.semis.core.designsystem.components.pills.StatusPill
+import org.saudigitus.semis.core.designsystem.components.rows.LabelValueRow
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
+import org.saudigitus.semis.core.designsystem.theme.contentTone
+import org.saudigitus.semis.core.designsystem.theme.light_success
+import org.saudigitus.semis.core.designsystem.theme.surfaceTone
+import org.saudigitus.semis.enrollment.R
+import org.saudigitus.semis.core.utils.DateHelper
+
+/**
+ * Identity attributes of the learner followed by the socio-economic records captured for
+ * them, mirroring the two panels of the web profile.
+ */
+@Composable
+internal fun StudentDetailsSection(
+    profile: TeiProfile,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        DetailCard(
+            title = stringResource(R.string.profile_identity),
+            imageVector = Icons.Outlined.Badge,
+            accent = SemisAccent.Blue,
+        ) {
+            if (profile.identity.isEmpty()) {
+                ProfileEmptyLine(text = stringResource(R.string.profile_no_identity))
+            } else {
+                profile.identity.forEach { attribute ->
+                    LabelValueRow(label = attribute.label, value = attribute.value)
+                }
+            }
+        }
+
+        DetailCard(
+            title = stringResource(R.string.profile_socio_economics),
+            imageVector = Icons.Outlined.Diversity3,
+            accent = SemisAccent.Purple,
+        ) {
+            if (profile.socioEconomics.isEmpty()) {
+                ProfileEmptyLine(text = stringResource(R.string.profile_no_socio_economics))
+            } else {
+                profile.socioEconomics.forEach { record ->
+                    SocioEconomicBlock(record = record)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SocioEconomicBlock(record: SocioEconomicRecord) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        LabelValueRow(
+            label = stringResource(R.string.profile_occurred_at),
+            value = record.occurredAt?.let { DateHelper.formatDate(it.time) },
+        )
+        LabelValueRow(
+            label = stringResource(R.string.profile_school),
+            value = record.orgUnitName,
+        )
+
+        if (record.isActive) {
+            StatusPill(
+                text = stringResource(R.string.profile_active),
+                containerColor = light_success.surfaceTone(alpha = .18f),
+                contentColor = light_success.contentTone(),
+            )
+        }
+
+        record.details.forEach { detail ->
+            LabelValueRow(label = detail.label, value = detail.value)
+        }
+    }
+}

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentPerformanceSection.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentPerformanceSection.kt
@@ -1,0 +1,71 @@
+package org.saudigitus.semis.enrollment.ui.profile.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.School
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.saudigitus.semis.core.data.model.profile.SubjectPerformance
+import org.saudigitus.semis.core.designsystem.components.cards.DetailCard
+import org.saudigitus.semis.core.designsystem.components.rows.LabelValueRow
+import org.saudigitus.semis.core.designsystem.theme.SemisAccent
+import org.saudigitus.semis.core.utils.DateHelper
+import org.saudigitus.semis.enrollment.R
+
+/**
+ * Marks the learner collected per subject over the selected academic year, each subject
+ * headed by the average those marks add up to.
+ */
+@Composable
+internal fun StudentPerformanceSection(
+    subjects: List<SubjectPerformance>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (subjects.isEmpty()) {
+            DetailCard(
+                title = stringResource(R.string.profile_performance),
+                imageVector = Icons.Outlined.School,
+                accent = SemisAccent.Amber,
+            ) {
+                ProfileEmptyLine(text = stringResource(R.string.profile_no_performance))
+            }
+            return@Column
+        }
+
+        subjects.forEach { subject ->
+            DetailCard(
+                title = subject.subject,
+                subtitle = subject.average?.let { average ->
+                    stringResource(R.string.profile_average, formatAverage(average))
+                },
+                imageVector = Icons.Outlined.School,
+                accent = SemisAccent.Amber,
+            ) {
+                subject.marks.forEach { mark ->
+                    LabelValueRow(
+                        label = listOfNotNull(
+                            mark.label.takeIf { it.isNotBlank() },
+                            mark.date?.let { DateHelper.formatDate(it.time) },
+                        ).joinToString(separator = " · "),
+                        value = mark.displayValue,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatAverage(average: Double): String =
+    if (average % 1.0 == 0.0) {
+        average.toInt().toString()
+    } else {
+        String.format("%.1f", average)
+    }

--- a/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentProfileHeader.kt
+++ b/semis/enrollment/src/main/java/org/saudigitus/semis/enrollment/ui/profile/components/StudentProfileHeader.kt
@@ -1,0 +1,90 @@
+package org.saudigitus.semis.enrollment.ui.profile.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import org.saudigitus.semis.core.designsystem.components.filters.FilterDetailsInfoCard
+import org.saudigitus.semis.core.designsystem.components.header.RoundedBottomHeader
+import org.saudigitus.semis.core.designsystem.components.stats.StatTileModel
+import org.saudigitus.semis.core.designsystem.components.stats.StatTileRow
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+import org.saudigitus.semis.core.designsystem.R as DesignSystemR
+
+/**
+ * Identity band of the learner dashboard: who the learner is, the selection the data is
+ * scoped to, and the counters summarising the academic year in view.
+ */
+@Composable
+internal fun StudentProfileHeader(
+    name: String,
+    systemId: String,
+    tiles: List<StatTileModel>,
+    filterDetailsState: FilterDetailsState,
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit,
+) {
+    RoundedBottomHeader(
+        modifier = modifier,
+        verticalSpacing = 14.dp,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onNavigateBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(DesignSystemR.string.back),
+                    tint = Color.White,
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = name,
+                    color = SemisPalette.OnHeaderPrimary,
+                    fontSize = 17.sp,
+                    lineHeight = 21.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    fontFamily = FontFamily(Font(DesignSystemR.font.rubik_bold)),
+                )
+                systemId.takeIf { it.isNotBlank() }?.let { value ->
+                    Text(
+                        text = value,
+                        color = SemisPalette.OnHeaderSecondary,
+                        fontSize = 12.5.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontFamily = FontFamily(Font(DesignSystemR.font.rubik_regular)),
+                    )
+                }
+            }
+        }
+
+        FilterDetailsInfoCard(state = filterDetailsState)
+
+        StatTileRow(tiles = tiles)
+    }
+}

--- a/semis/enrollment/src/main/res/values/strings.xml
+++ b/semis/enrollment/src/main/res/values/strings.xml
@@ -1,3 +1,29 @@
 <resources>
     <string name="app_name">enrollment</string>
+
+    <string name="profile_tab_details">Details</string>
+    <string name="profile_tab_attendance">Attendance</string>
+    <string name="profile_tab_performance">Performance</string>
+
+    <string name="profile_identity">Identity</string>
+    <string name="profile_socio_economics">Socio-economic details</string>
+    <string name="profile_attendance_summary">Attendance summary</string>
+    <string name="profile_attendance_history">Recorded days</string>
+    <string name="profile_performance">Performance</string>
+
+    <string name="profile_occurred_at">Occurred at</string>
+    <string name="profile_school">School</string>
+    <string name="profile_active">Active</string>
+    <string name="profile_average">Average %1$s</string>
+    <string name="profile_recorded">Recorded</string>
+    <string name="profile_recorded_days">%1$d day(s) recorded</string>
+    <string name="profile_more_records">%1$d more day(s) not listed</string>
+    <string name="profile_unknown_date">Unknown date</string>
+    <string name="profile_unknown_learner">Learner</string>
+
+    <string name="profile_no_identity">No identity attributes were captured for this learner.</string>
+    <string name="profile_no_socio_economics">No socio-economic record was captured for this learner.</string>
+    <string name="profile_no_attendance">No attendance was recorded for the selected academic year.</string>
+    <string name="profile_no_performance">No marks were recorded for the selected academic year.</string>
+    <string name="profile_not_found">This learner profile could not be loaded.</string>
 </resources>

--- a/semis/enrollment/src/test/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTilesTest.kt
+++ b/semis/enrollment/src/test/java/org/saudigitus/semis/enrollment/ui/profile/StudentProfileTilesTest.kt
@@ -1,0 +1,117 @@
+package org.saudigitus.semis.enrollment.ui.profile
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.saudigitus.semis.core.data.model.profile.AttendanceHistory
+import org.saudigitus.semis.core.data.model.profile.AttendanceRecord
+import org.saudigitus.semis.core.data.model.profile.AttendanceStatusCount
+import org.saudigitus.semis.core.data.model.profile.TeiProfile
+
+class StudentProfileTilesTest {
+
+    private fun statusCount(
+        key: String,
+        count: Int,
+        color: String? = null,
+    ) = AttendanceStatusCount(
+        key = key,
+        code = key.uppercase(),
+        label = key.replaceFirstChar { it.uppercase() },
+        color = color,
+        count = count,
+    )
+
+    private fun record(index: Int) = AttendanceRecord(
+        eventUid = "event-$index",
+        date = null,
+        statusCode = "PRESENT",
+        statusLabel = "Present",
+        absenceReason = null,
+    )
+
+    private fun profile(
+        statuses: List<AttendanceStatusCount>,
+        recordedDays: Int = 0,
+    ) = TeiProfile(
+        teiUid = "tei",
+        name = "Miranda Bailer",
+        systemId = "2025-00000085",
+        attendance = AttendanceHistory(
+            records = (0 until recordedDays).map(::record),
+            statusCounts = statuses,
+        ),
+    )
+
+    @Test
+    fun `the recorded days lead the counters and each configured status follows`() {
+        val tiles = studentProfileTiles(
+            recordedDaysLabel = "Recorded",
+            profile = profile(
+                statuses = listOf(
+                    statusCount("present", 2),
+                    statusCount("absent", 1),
+                ),
+                recordedDays = 3,
+            ),
+        )
+
+        assertEquals(listOf("Recorded", "Present", "Absent"), tiles.map { it.label })
+        assertEquals(listOf(3, 2, 1), tiles.map { it.value })
+    }
+
+    @Test
+    fun `a status the learner has no day of still reports zero`() {
+        val tiles = studentProfileTiles(
+            recordedDaysLabel = "Recorded",
+            profile = profile(
+                statuses = listOf(
+                    statusCount("present", 0),
+                    statusCount("absent", 0),
+                    statusCount("late", 0),
+                ),
+            ),
+        )
+
+        assertEquals(listOf("Recorded", "Present", "Absent", "Late"), tiles.map { it.label })
+        assertEquals(listOf(0, 0, 0, 0), tiles.map { it.value })
+    }
+
+    @Test
+    fun `no counter is built when the program configures no attendance status`() {
+        val tiles = studentProfileTiles(
+            recordedDaysLabel = "Recorded",
+            profile = profile(statuses = emptyList(), recordedDays = 4),
+        )
+
+        assertEquals(emptyList<String>(), tiles.map { it.label })
+    }
+
+    @Test
+    fun `no counter is built until the profile is loaded`() {
+        assertEquals(
+            emptyList<String>(),
+            studentProfileTiles(recordedDaysLabel = "Recorded", profile = null).map { it.label },
+        )
+    }
+
+    @Test
+    fun `a status is painted with the color it is configured with`() {
+        val tiles = studentProfileTiles(
+            recordedDaysLabel = "Recorded",
+            profile = profile(statuses = listOf(statusCount("absent", 1, color = "#E57373"))),
+        )
+
+        assertEquals(Color(0xFFE57373), tiles[1].containerColor)
+    }
+
+    @Test
+    fun `a status without a configured color falls back to its key default`() {
+        val tiles = studentProfileTiles(
+            recordedDaysLabel = "Recorded",
+            profile = profile(statuses = listOf(statusCount("late", 1))),
+        )
+
+        assertEquals(Color(0xFFFACC95), tiles[1].containerColor)
+    }
+}


### PR DESCRIPTION
* Introduce the `StudentProfileScreen` to provide a comprehensive view of learner identity, socio-economic details, attendance history, and academic performance.
* Implement `TeiProfileRepository` to aggregate profile data, including attendance summaries and subject marks filtered by the selected academic year.
* Add reusable UI components to the design system, including `DetailCard` for grouped data, `LabelValueRow` for consistent property display, and `SegmentedTabRow` for pill-style section navigation.
* Migrate the attendance filter display into a generic `FilterDetailsInfoCard` for use in both the attendance and profile headers.
* Extend the enrollment module to support navigation to the student profile dashboard upon clicking a learner card.
* Implement logic to calculate subject-specific performance averages and summarize attendance status counts (Present, Absent, etc.) for the dashboard header.
* Add unit tests to verify subject performance average calculations and the dynamic generation of attendance status tiles.
* Update string resources to support localized labels for identity attributes, socio-economic records, and performance summaries.
* Integrate the profile route and ViewModel into `AppNavGraph` with support for `teiUid` and program-based initialization.