### PR TITLE
fix: [SEMIS-146] Fixes Option Filters Ignoring Program Rule Conditions

### DIFF
--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/OptionRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/OptionRepositoryImpl.kt
@@ -5,10 +5,10 @@ import kotlinx.coroutines.withContext
 import org.dhis2.commons.bindings.dataElement
 import org.hisp.dhis.android.core.D2
 import org.saudigitus.semis.core.data.rules.RuleEngineRepository
+import org.saudigitus.semis.core.data.rules.isOptionVisible
 import org.saudigitus.semis.core.data.utils.optionByOptionSet
+import org.saudigitus.semis.core.data.utils.optionUidsInOptionGroups
 import org.saudigitus.semis.core.data.utils.optionsByOptionSetAndCode
-import org.saudigitus.semis.core.data.utils.optionsNotInOptionGroup
-import org.saudigitus.semis.core.data.utils.optionsNotInOptionsSets
 import javax.inject.Inject
 
 class OptionRepositoryImpl
@@ -22,13 +22,21 @@ class OptionRepositoryImpl
         dataElement: String
     ) = withContext(Dispatchers.IO) {
         val optionSet = d2.dataElement(dataElement)?.optionSetUid()
+        val options = d2.optionByOptionSet(optionSet)
 
-        val hideOptions = ruleEngineRepository.applyOptionRules(ou, program, dataElement)
+        val effects = ruleEngineRepository.applyOptionRules(ou, program, dataElement)
+        if (effects.restrictsNothing) {
+            return@withContext options
+        }
 
-        when {
-            hideOptions.isEmpty() -> d2.optionByOptionSet(optionSet)
-            ou != null -> d2.optionsNotInOptionGroup(hideOptions, optionSet)
-            else -> d2.optionsNotInOptionsSets(hideOptions, optionSet)
+        val optionUidsToHide = effects.optionsToHide.toSet() +
+            d2.optionUidsInOptionGroups(effects.optionGroupsToHide)
+        val optionUidsToShow = effects.optionGroupsToShow
+            .takeIf { it.isNotEmpty() }
+            ?.let { d2.optionUidsInOptionGroups(it) }
+
+        options.filter { option ->
+            isOptionVisible(option.uid(), optionUidsToHide, optionUidsToShow)
         }
     }
 

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/rules/OptionRuleEffects.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/rules/OptionRuleEffects.kt
@@ -1,0 +1,42 @@
+package org.saudigitus.semis.core.data.rules
+
+/**
+ * Restrictions that the option level program rules placed on a single field.
+ *
+ * DHIS2 narrows the options offered for a field in two opposite ways: by hiding single options or
+ * whole option groups, or by revealing an option group. The two are not additive. Revealing a group
+ * turns that group into the only valid choice for the field, which supersedes every hide effect, so
+ * the three sets are kept apart instead of collapsed into one list of uids that could no longer tell
+ * an option from a group nor a hide from a reveal.
+ */
+data class OptionRuleEffects(
+    val optionsToHide: List<String> = emptyList(),
+    val optionGroupsToHide: List<String> = emptyList(),
+    val optionGroupsToShow: List<String> = emptyList(),
+) {
+    /**
+     * True when no rule applied to the field, so the caller can serve the option set untouched
+     * instead of resolving group membership it would never use.
+     */
+    val restrictsNothing: Boolean
+        get() = optionsToHide.isEmpty() &&
+            optionGroupsToHide.isEmpty() &&
+            optionGroupsToShow.isEmpty()
+}
+
+/**
+ * Decides whether [optionUid] survives the option level rules.
+ *
+ * [optionUidsToShow] is null when no rule revealed an option group. When it is present it decides
+ * on its own and the hidden uids are not consulted, because revealing a group restricts the field
+ * to that group rather than adding to what is already visible. Both sets hold option uids, so the
+ * caller resolves group membership beforehand.
+ */
+internal fun isOptionVisible(
+    optionUid: String,
+    optionUidsToHide: Set<String>,
+    optionUidsToShow: Set<String>?,
+): Boolean = when (optionUidsToShow) {
+    null -> optionUid !in optionUidsToHide
+    else -> optionUid in optionUidsToShow
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/rules/RuleEngineRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/rules/RuleEngineRepository.kt
@@ -26,6 +26,8 @@ import org.hisp.dhis.rules.models.RuleEvent
 import org.hisp.dhis.rules.models.RuleEventStatus
 import org.hisp.dhis.rules.models.RuleVariable
 import java.util.Collections
+import java.util.Date
+import java.util.UUID
 import javax.inject.Inject
 
 class RuleEngineRepository @Inject constructor(
@@ -204,32 +206,82 @@ class RuleEngineRepository @Inject constructor(
         )
     }
 
+    /**
+     * Resolves the option level rules that restrict [dataElement] of [program] for the school [ou].
+     *
+     * These rules carry conditions such as `d2:inOrgUnitGroup('SSS')`, so their actions only apply to
+     * the schools the condition matches. Reading the actions off the configured rules would apply
+     * every restriction to every school, so the rules are evaluated instead: the engine returns the
+     * effects of the rules whose condition held, and discards the rest.
+     *
+     * The engine only evaluates conditions against a target it can read the school from, so a
+     * throwaway target carrying [ou] stands in for the record being filled. Without [ou] no
+     * organisation unit condition can hold and the field keeps its full option set.
+     */
     suspend fun applyOptionRules(
         ou: String? = null,
         program: String,
         dataElement: String,
-    ) = withContext(Dispatchers.IO) {
-        val ruleContext = executeContext(ou, program)
-        ruleContext.rules
-            .asSequence()
-            .flatMap { it.actions.asSequence() }
-            .filter {
-                it.type in setOf(
-                    ProgramRuleActionType.HIDEOPTION.name,
-                    ProgramRuleActionType.HIDEOPTIONGROUP.name
-                )
-            }
-            .mapNotNull { action ->
-                val fieldMatches = action.values["field"] == dataElement
-                if (!fieldMatches) return@mapNotNull null
+    ): OptionRuleEffects = withContext(Dispatchers.IO) {
+        val optionsToHide = mutableListOf<String>()
+        val optionGroupsToHide = mutableListOf<String>()
+        val optionGroupsToShow = mutableListOf<String>()
 
+        ruleEngine.evaluate(
+            target = optionRuleTarget(ou),
+            ruleEnrollment = null,
+            ruleEvents = emptyList(),
+            executionContext = executeContext(ou, program),
+        ).asSequence()
+            .map { it.ruleAction }
+            .filter { it.field() == dataElement }
+            .forEach { action ->
                 when (action.type) {
-                    ProgramRuleActionType.HIDEOPTION.name -> action.values["option"]
-                    ProgramRuleActionType.HIDEOPTIONGROUP.name -> action.values["optionGroup"]
-                    else -> null
+                    ProgramRuleActionType.HIDEOPTION.name ->
+                        action.values["option"]?.let(optionsToHide::add)
+
+                    ProgramRuleActionType.HIDEOPTIONGROUP.name ->
+                        action.values["optionGroup"]?.let(optionGroupsToHide::add)
+
+                    ProgramRuleActionType.SHOWOPTIONGROUP.name ->
+                        action.values["optionGroup"]?.let(optionGroupsToShow::add)
+
+                    // Every other action type shapes the form, not the option list of this field.
+                    else -> Unit
                 }
             }
-            .toList()
+
+        return@withContext OptionRuleEffects(
+            optionsToHide = optionsToHide,
+            optionGroupsToHide = optionGroupsToHide,
+            optionGroupsToShow = optionGroupsToShow,
+        )
+    }
+
+    /**
+     * Builds the throwaway target the option rules are evaluated against.
+     *
+     * Nothing here is persisted and no program stage is involved: the target exists only to carry
+     * [ou], which is the value `d2:inOrgUnitGroup` matches against the organisation unit groups
+     * published in the context supplementary data. Filtering an option list happens before any
+     * record exists, so there is no real event to evaluate instead. The current date stands in for
+     * the event date so that a date based condition is evaluated as of now.
+     */
+    private fun optionRuleTarget(ou: String?): RuleEvent {
+        val now = Date()
+        return RuleEvent(
+            event = UUID.randomUUID().toString(),
+            programStage = "",
+            programStageName = "",
+            status = RuleEventStatus.ACTIVE,
+            eventDate = now.toRuleEngineInstant(),
+            createdDate = now.toRuleEngineInstant(),
+            dueDate = null,
+            completedDate = null,
+            organisationUnit = ou.orEmpty(),
+            organisationUnitCode = ou?.let { d2.organisationUnit(it)?.code() },
+            dataValues = emptyList(),
+        )
     }
 
     private fun dataEntry(

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Extensions.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/utils/Extensions.kt
@@ -42,36 +42,27 @@ fun D2.optionByOptionSet(
     .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
     .blockingGet()
 
-fun D2.optionsNotInOptionsSets(
-    options: List<String>,
-    optionSet: String?,
-): List<Option> = optionModule()
-    .options()
-    .byUid().notIn(options)
-    .byOptionSetUid().eq(optionSet)
-    .orderByDisplayName(RepositoryScope.OrderByDirection.ASC)
-
-    .blockingGet()
-
-fun D2.optionsNotInOptionGroup(
+/**
+ * Uids of every option that belongs to any of [optionGroups].
+ *
+ * Option level program rules address whole groups while the list they restrict is made of single
+ * options, so the membership has to be resolved before a rule can be applied to an option list.
+ */
+fun D2.optionUidsInOptionGroups(
     optionGroups: List<String>,
-    optionSet: String?,
-): List<Option> = optionModule()
-    .optionGroups()
-    .byUid().notIn(optionGroups)
-    .byOptionSetUid().eq(optionSet)
-    .withOptions()
-    .orderByDisplayName(RepositoryScope.OrderByDirection.ASC)
-    .blockingGet()
-    .flatMap {
-        it.options() ?: emptyList()
-    }.flatMap {
-        optionModule()
-            .options()
-            .byUid().eq(it.uid())
-            .orderBySortOrder(RepositoryScope.OrderByDirection.ASC)
-            .blockingGet()
-    }
+): Set<String> {
+    if (optionGroups.isEmpty()) return emptySet()
+
+    return optionModule()
+        .optionGroups()
+        .byUid().`in`(optionGroups)
+        .withOptions()
+        .blockingGet()
+        .flatMap { optionGroup ->
+            optionGroup.options()?.map { it.uid() } ?: emptyList()
+        }
+        .toSet()
+}
 
 fun D2.optionsByOptionSetAndCode(
     optionSet: String?,

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/rules/OptionRuleEffectsTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/rules/OptionRuleEffectsTest.kt
@@ -1,0 +1,90 @@
+package org.saudigitus.semis.core.data.rules
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The scenarios below mirror the grade configuration the schools are set up with: the grades are
+ * split into a primary, a lower secondary and an upper secondary option group, and each school type
+ * is restricted to the groups it teaches.
+ */
+class OptionRuleEffectsTest {
+
+    private val primary = setOf("grade1", "grade2", "grade3", "grade4", "grade5", "grade6")
+    private val lowerSecondary = setOf("grade7", "grade8", "grade9")
+    private val allGrades = (primary + lowerSecondary + setOf("grade10", "grade11", "grade12")).toList()
+
+    private fun visibleGrades(
+        optionUidsToHide: Set<String> = emptySet(),
+        optionUidsToShow: Set<String>? = null,
+    ) = allGrades.filter { isOptionVisible(it, optionUidsToHide, optionUidsToShow) }
+
+    @Test
+    fun `a school matched by no rule keeps every grade`() {
+        val effects = OptionRuleEffects()
+
+        assertTrue(effects.restrictsNothing)
+        assertEquals(allGrades, visibleGrades())
+    }
+
+    @Test
+    fun `a school that teaches upper secondary only loses the grades of the hidden groups`() {
+        val effects = OptionRuleEffects(optionGroupsToHide = listOf("primary", "lowerSecondary"))
+
+        assertFalse(effects.restrictsNothing)
+        assertEquals(
+            listOf("grade10", "grade11", "grade12"),
+            visibleGrades(optionUidsToHide = primary + lowerSecondary),
+        )
+    }
+
+    @Test
+    fun `hiding one group leaves the grades of the other groups untouched`() {
+        assertEquals(
+            listOf(
+                "grade1", "grade2", "grade3", "grade4", "grade5", "grade6",
+                "grade10", "grade11", "grade12",
+            ),
+            visibleGrades(optionUidsToHide = lowerSecondary),
+        )
+    }
+
+    @Test
+    fun `a revealed group becomes the only choice even when nothing was hidden`() {
+        val effects = OptionRuleEffects(optionGroupsToShow = listOf("primary"))
+
+        assertFalse(effects.restrictsNothing)
+        assertEquals(primary.toList(), visibleGrades(optionUidsToShow = primary))
+    }
+
+    @Test
+    fun `a revealed group overrides the groups another rule hid`() {
+        assertEquals(
+            primary.toList(),
+            visibleGrades(optionUidsToHide = primary + lowerSecondary, optionUidsToShow = primary),
+        )
+    }
+
+    @Test
+    fun `an option hidden on its own is dropped without touching its group`() {
+        val effects = OptionRuleEffects(optionsToHide = listOf("grade7"))
+
+        assertFalse(effects.restrictsNothing)
+        assertEquals(
+            allGrades - "grade7",
+            visibleGrades(optionUidsToHide = setOf("grade7")),
+        )
+    }
+
+    @Test
+    fun `an option that belongs to no group survives a group level hide`() {
+        val ungrouped = allGrades + "gradeUngrouped"
+
+        assertEquals(
+            listOf("grade10", "grade11", "grade12", "gradeUngrouped"),
+            ungrouped.filter { isOptionVisible(it, primary + lowerSecondary, null) },
+        )
+    }
+}


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-146).

### Problem

Filters backed by an option set read their hide actions straight off the configured program rules, without ever evaluating the rule conditions. Every `HIDEOPTION`/`HIDEOPTIONGROUP` action was therefore applied to every school, no matter which organisation unit group the school belonged to, and `SHOWOPTIONGROUP` was never processed at all.

On the Grade filter this left the same three grades selectable for every school, including the ones that teach none of them. Any other option backed field configured with these rules is affected the same way, since the defect sits in the shared code path.

The returned hide list also mixed option uids with option group uids, and the caller disambiguated them by whether an organisation unit had been passed, which could not express the two kinds of restriction.

### Solution

- Evaluate the rules through the rule engine instead of reading their actions, so only the rules whose condition holds for the selected school restrict the option list. Evaluation needs a target to read the organisation unit from, so a throwaway target carrying it stands in for the record being filled, which does not exist yet while a filter is built. This follows the precedent already in the repository, where the stock use case evaluates rules against an event it never persists.
- Process `SHOWOPTIONGROUP` with the precedence the base app applies in `FormBaseConfiguration`: once a group is revealed for a field, it becomes the only valid choice and the hide effects are superseded.
- Keep the option and option group effects apart in `OptionRuleEffects`, and resolve group membership before filtering. As a side effect this fixes options that belong to no group being dropped by a group level hide.
- Drop `optionsNotInOptionsSets` and `optionsNotInOptionGroup`, which the change leaves unused. Verified beforehand that neither has any remaining call site; the same named functions in the campaign modules are a different package and were left untouched.

### Validation

- `./gradlew` unit test sweep over the nine SEMIS modules: 100 tests, 0 failures, up from 93 (seven new cases covering the school type scenarios, the reveal precedence, and an option outside every group).
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- Not verified at runtime against a live server: the rule evaluation path itself was confirmed by reading the rule engine sources, not by exercising the built app.