### PR TITLE
fix: [SEMIS-147] Fixes Auto Generated Attributes Never Filled in the Enrollment Form

### DIFF
--- a/semis-core/data/src/semisEnrollment/java/org/saudigitus/campaign/core/data/models/EnrollmentFormModels.kt
+++ b/semis-core/data/src/semisEnrollment/java/org/saudigitus/campaign/core/data/models/EnrollmentFormModels.kt
@@ -35,6 +35,11 @@ data class TrackedEntityAttributeModel(
     val valueType: ValueType? = ValueType.TEXT,
     val mandatory: Boolean? = false,
     val sortOrder: Int? = -1,
+    /**
+     * The server mints this attribute from a pattern instead of letting anyone type it, so the
+     * form has to obtain the value from the reserve rather than leave the field for the user.
+     */
+    val generated: Boolean = false,
 )
 
 data class TrackedEntityAttributeSectionModel(

--- a/semis-core/data/src/semisEnrollment/java/org/saudigitus/campaign/core/data/repository/impl/SemisEnrollmentRepositories.kt
+++ b/semis-core/data/src/semisEnrollment/java/org/saudigitus/campaign/core/data/repository/impl/SemisEnrollmentRepositories.kt
@@ -97,12 +97,13 @@ class SemisEnrollmentProgramRepository(private val d2: D2) : ProgramRepository {
                 ?: return@mapNotNull null
             val attribute = attributesByUid[attributeUid] ?: return@mapNotNull null
             TrackedEntityAttributeModel(
-                attribute.uid(),
-                attribute.displayFormName(),
-                attribute.code(),
-                attribute.optionSet()?.uid(),
-                attribute.valueType(),
-                programAttribute.mandatory() ?: false,
+                uid = attribute.uid(),
+                displayFormName = attribute.displayFormName(),
+                code = attribute.code(),
+                optionSetUid = attribute.optionSet()?.uid(),
+                valueType = attribute.valueType(),
+                mandatory = programAttribute.mandatory() ?: false,
+                generated = attribute.generated() ?: false,
             )
         }
     }
@@ -119,15 +120,37 @@ class SemisEnrollmentProgramRepository(private val d2: D2) : ProgramRepository {
             .blockingGet()
             .associateBy { it.trackedEntityAttribute()?.uid() }
 
+        // The attributes linked to a section carry only what the link table holds, so the full
+        // records are read separately to reach the flags the form depends on, such as generated.
+        val sectionAttributeUids = sections.flatMap { section ->
+            section.attributes().orEmpty().map { it.uid() }
+        }.distinct()
+        val attributesByUid = if (sectionAttributeUids.isEmpty()) {
+            emptyMap()
+        } else {
+            d2.trackedEntityModule().trackedEntityAttributes()
+                .byUid().`in`(sectionAttributeUids)
+                .blockingGet()
+                .associateBy { it.uid() }
+        }
+
         sections.map { section ->
             TrackedEntityAttributeSectionModel(
                 uid = section.uid(), code = section.code(), displayName = section.displayName(),
                 description = section.description(), sortOrder = section.sortOrder(),
-                attributes = section.attributes().orEmpty().mapNotNull { attribute ->
-                    val programAttribute = programAttributesByAttribute[attribute.uid()]
+                attributes = section.attributes().orEmpty().mapNotNull { sectionAttribute ->
+                    val programAttribute = programAttributesByAttribute[sectionAttribute.uid()]
                         ?: return@mapNotNull null
-                    TrackedEntityAttributeModel(attribute.uid(), attribute.displayFormName(), attribute.code(),
-                        attribute.optionSet()?.uid(), attribute.valueType(), programAttribute.mandatory() ?: false)
+                    val attribute = attributesByUid[sectionAttribute.uid()] ?: sectionAttribute
+                    TrackedEntityAttributeModel(
+                        uid = attribute.uid(),
+                        displayFormName = attribute.displayFormName(),
+                        code = attribute.code(),
+                        optionSetUid = attribute.optionSet()?.uid(),
+                        valueType = attribute.valueType(),
+                        mandatory = programAttribute.mandatory() ?: false,
+                        generated = attribute.generated() ?: false,
+                    )
                 },
             )
         }.sortedBy { it.sortOrder }

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/data/repository/SemisEnrollmentFormRepository.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/data/repository/SemisEnrollmentFormRepository.kt
@@ -2,15 +2,19 @@ package org.saudigitus.campaign.core.form.data.repository
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.dhis2.commons.resources.ResourceManager
 import org.hisp.dhis.android.core.D2
+import org.hisp.dhis.android.core.common.ValueType
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.campaign.core.data.models.OptionModel
 import org.saudigitus.campaign.core.data.models.OrgUnit
 import org.saudigitus.campaign.core.data.models.OuHideStrategy
+import org.saudigitus.campaign.core.data.models.TrackedEntityAttributeModel
 import org.saudigitus.campaign.core.data.repository.EnrollmentRepository
 import org.saudigitus.campaign.core.data.repository.OptionRepository
 import org.saudigitus.campaign.core.data.repository.ProgramRepository
+import org.saudigitus.campaign.core.form.R
 import org.saudigitus.campaign.core.form.data.models.FormFieldModel
 import org.saudigitus.campaign.core.form.data.models.FormResult
 import org.saudigitus.campaign.core.form.data.models.FormSectionModel
@@ -31,7 +35,16 @@ class SemisEnrollmentFormRepository @Inject constructor(
     private val optionRepository: OptionRepository,
     private val programRepository: ProgramRepository,
     private val enrollmentRepository: EnrollmentRepository,
+    private val resourceManager: ResourceManager,
 ) : FormRepository {
+
+    private companion object {
+        /**
+         * How many reserved values may be discarded before giving up on finding a usable one.
+         * Each attempt costs a value from the reserve, so the search stays deliberately short.
+         */
+        const val MAX_RESERVED_VALUE_ATTEMPTS = 5
+    }
     override suspend fun save(
         formType: FormSectionType,
         orgUnit: String,
@@ -200,6 +213,8 @@ class SemisEnrollmentFormRepository @Inject constructor(
         program: String,
         tei: String?,
     ): List<FormSectionModel> = withContext(Dispatchers.IO) {
+        val storedValues = attributeValues(tei)
+
         programRepository.getTrackedEntityAttributeWithSection(program).map { section ->
             FormSectionModel(
                 uid = section.uid,
@@ -209,10 +224,22 @@ class SemisEnrollmentFormRepository @Inject constructor(
                 sortOrder = section.sortOrder,
                 formFields = section.attributes.map { attribute ->
                     val optionSetUid = attribute.optionSetUid
+                    val storedValue = storedValues[attribute.uid]
+                    val reserved = if (attribute.generated && storedValue == null) {
+                        reserveGeneratedValue(attribute, orgUnit)
+                    } else {
+                        null
+                    }
+
                     FormFieldModel(
                         uid = attribute.uid,
                         label = attribute.displayFormName.orEmpty(),
                         valueType = attribute.valueType,
+                        value = storedValue ?: reserved?.value,
+                        // A generated value belongs to the server, so it is shown but not typed over.
+                        enabled = !attribute.generated,
+                        hasWarning = reserved?.warning != null,
+                        warningMessage = reserved?.warning,
                         mandatory = attribute.mandatory,
                         baseMandatory = attribute.mandatory,
                         optionSet = if (optionSetUid != null) {
@@ -230,6 +257,91 @@ class SemisEnrollmentFormRepository @Inject constructor(
             )
         }
     }
+
+    /**
+     * Value already stored for each attribute of [tei], keyed by attribute uid.
+     *
+     * Two things depend on this. An enrollment being edited shows what was captured before, and an
+     * attribute that already holds a generated value stops consuming a fresh one from the reserve
+     * every time the form is reopened, which would both exhaust the reserve and change an
+     * identifier that other records already refer to.
+     */
+    private fun attributeValues(tei: String?): Map<String, String> {
+        if (tei.isNullOrBlank()) return emptyMap()
+
+        return d2.trackedEntityModule().trackedEntityAttributeValues()
+            .byTrackedEntityInstance().eq(tei)
+            .blockingGet()
+            .mapNotNull { attributeValue ->
+                val uid = attributeValue.trackedEntityAttribute() ?: return@mapNotNull null
+                val value = attributeValue.value()?.takeIf(String::isNotBlank)
+                    ?: return@mapNotNull null
+                uid to value
+            }
+            .toMap()
+    }
+
+    /**
+     * Takes the next value the server reserved for [attribute] at [orgUnit].
+     *
+     * The pattern behind a generated attribute is deliberately never interpreted here. Sequential
+     * values are allocated by the server so that two devices cannot mint the same identifier, and
+     * the SDK owns the reserve, its refill and the patterns whose result varies per organisation
+     * unit. Delegating to it is what keeps this working for whatever pattern a deployment
+     * configures, instead of only for the ones seen so far.
+     *
+     * Every call consumes a value, hence it is only reached for an attribute with none stored yet.
+     */
+    private fun reserveGeneratedValue(
+        attribute: TrackedEntityAttributeModel,
+        orgUnit: String,
+    ): ReservedValue {
+        val value = try {
+            if (orgUnit.isBlank()) null else nextUsableReservedValue(attribute, orgUnit)
+        } catch (_: Exception) {
+            // The reserve is refilled while syncing, so running dry offline is expected rather
+            // than exceptional, and it must not take the whole form down with it.
+            null
+        }
+
+        return when (value) {
+            null -> ReservedValue(
+                value = null,
+                warning = resourceManager.getString(R.string.reserved_value_unavailable),
+            )
+
+            else -> ReservedValue(value = value, warning = null)
+        }
+    }
+
+    /**
+     * Next reserved value that is valid for the value type of [attribute], or null when none is.
+     *
+     * A number cannot carry a leading zero, so such a value is dropped instead of being stored as
+     * something the server would later reject. The retries are capped because each one costs a
+     * value from the reserve, and a pattern that only ever yields leading zeros is a configuration
+     * problem that draining the reserve would not solve.
+     */
+    private fun nextUsableReservedValue(
+        attribute: TrackedEntityAttributeModel,
+        orgUnit: String,
+    ): String? {
+        val reservedValueManager = d2.trackedEntityModule().reservedValueManager()
+        var value = reservedValueManager.blockingGetValue(attribute.uid, orgUnit)
+
+        if (attribute.valueType != ValueType.NUMBER) return value
+
+        var attempts = 1
+        while (value.startsWith("0") && attempts < MAX_RESERVED_VALUE_ATTEMPTS) {
+            value = reservedValueManager.blockingGetValue(attribute.uid, orgUnit)
+            attempts++
+        }
+
+        return value.takeIf { !it.startsWith("0") }
+    }
+
+    /** Outcome of reserving a value: the value itself, or the warning to show when there is none. */
+    private data class ReservedValue(val value: String?, val warning: String?)
 
     override suspend fun applyProgramRules(
         orgUnit: String,

--- a/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/di/FormModule.kt
+++ b/semis-core/form/src/main/java/org/saudigitus/campaign/core/form/di/FormModule.kt
@@ -15,6 +15,7 @@ val campaignFormModule = module {
             optionRepository = get(),
             programRepository = get(),
             enrollmentRepository = get(),
+            resourceManager = ResourceManager(androidContext(), get()),
         )
     }
     viewModel {

--- a/semis-core/form/src/main/res/values-pt/strings.xml
+++ b/semis-core/form/src/main/res/values-pt/strings.xml
@@ -15,4 +15,5 @@
     <string name="num_of_mandatory_field">Campo(s) obrigatório(s): %s campo(s)</string>
     <string name="semis_form_yes">Sim</string>
     <string name="semis_form_no">Não</string>
+    <string name="reserved_value_unavailable">Nenhum valor disponível. Sincronize os dados para obter novos valores.</string>
 </resources>

--- a/semis-core/form/src/main/res/values/strings.xml
+++ b/semis-core/form/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="separator">|</string>
     <string name="semis_form_yes">Yes</string>
     <string name="semis_form_no">No</string>
+    <string name="reserved_value_unavailable">No value available. Sync the data to get new values.</string>
 </resources>


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-147).

### Problem

The enrollment form had no notion of a generated attribute at all. The `generated` flag was never read from the SDK, the attribute model carried no such field, and no module in the SEMIS tree ever asked the reserved value manager for a value. Attributes the server mints from a pattern therefore opened empty, and since one of them is mandatory, there was no value the user could type and the enrollment could never be completed.

Two further gaps sat in the same code path: the form section builder received the organisation unit and the tracked entity and used neither, so an enrollment being edited also opened with every field empty, and there was nothing to stop a generated value being requested again for an attribute that already held one.

### Solution

- Carry the `generated` flag from the SDK through `TrackedEntityAttributeModel` into the form field. In the section branch the full attribute records are read separately, since the attributes linked to a section only carry what the link table holds.
- Take the value from the SDK reserved value manager instead of interpreting the pattern. Sequential values are allocated by the server so that two devices cannot mint the same identifier, and the SDK owns the reserve, its refill and the patterns whose result depends on the organisation unit, so delegating keeps this working for whatever pattern a deployment configures rather than only for the ones seen so far.
- Read the values already stored for the tracked entity and only reserve one for an attribute that has none. Each request consumes a value from the reserve, so this both stops the reserve draining on every reopen and stops an identifier changing under records that already point at it. It also makes an edited enrollment show what was captured before.
- Render a generated field read only, since the value belongs to the server.
- Surface a warning when no value can be obtained. The reserve is refilled while syncing, so running dry offline is expected and must not take the form down. Retries for a value type that cannot accept the value are capped, because each attempt costs a value from the reserve.

### Validation

Verified at runtime against the dev server, on the emulator, after installing this build:

| | Before | After |
|---|---|---|
| Unique Student Registration Number (mandatory) | empty | `2026-00001353` |
| Internal ID | empty | `2026-Xh000000` |
| Editable by the user | n/a | no, both read only |
| Mandatory field left blocking the save | yes | no |

Both configured pattern kinds resolved correctly, a server allocated sequential one and a locally generated random one, which is the point of delegating to the SDK.

Also: unit test sweep over the nine SEMIS modules, 93 tests, 0 failures; `./gradlew assembleDhis2Debug`, what CI runs, BUILD SUCCESSFUL.

Not covered: no unit tests were added. The logic lives in a repository bound to D2 and the campaign tree has no established test convention, so the evidence here is the runtime verification rather than an automated test.

Unrelated observation, not changed here: the form banner reads `countMandatoryFields()`, the total number of mandatory fields, rather than `countUnfilledMandatoryFields()`, so it keeps showing the same count once a field is filled. Pre-existing and out of scope for this ticket.