### PR TITLE
feat: [SEMIS-150] enable the module cards from the filter selection

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeNotice.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeNotice.kt
@@ -1,0 +1,19 @@
+package org.saudigitus.semis.app.presentation.home
+
+/**
+ * What the home screen has to tell the user about the class they picked.
+ *
+ * An incomplete selection and a class without learners both leave the listing empty, but they ask
+ * different things of the user: one is missing a choice, the other is missing data. Keeping them
+ * apart is what lets the screen say which of the two it is.
+ */
+enum class HomeNotice {
+    /** The class is chosen and holds learners, so there is nothing to report. */
+    NONE,
+
+    /** The user has still to pick the school, the academic year or one of the configured filters. */
+    SELECT_FILTERS,
+
+    /** The selection is complete but nothing has been downloaded or enrolled under it yet. */
+    NO_DATA,
+}

--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeScreen.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeScreen.kt
@@ -70,6 +70,7 @@ fun HomeScreen(
     ) {
         val filterDetails = state.filterState.filterDetailsState
         val stats = homeStats(state)
+        val noticeMessage = state.errorMessage ?: state.notice.message()
 
         LazyVerticalGrid(
             modifier = Modifier.fillMaxSize(),
@@ -87,12 +88,11 @@ fun HomeScreen(
                 )
             }
 
-            if (filterDetails.count == 0) {
-                fullWidthItem(key = "no_records") {
+            if (noticeMessage != null) {
+                fullWidthItem(key = "notice") {
                     NoRecordsFound(
                         modifier = Modifier.fillMaxWidth(),
-                        message = state.errorMessage
-                            ?: stringResource(DesignSystemR.string.no_records_found)
+                        message = noticeMessage
                     )
                 }
             }
@@ -107,7 +107,7 @@ fun HomeScreen(
                         label = module.title,
                         icon = painterResource(ModuleIcons.getModuleIconByName(module.icon)),
                         accent = moduleAccent(module.icon),
-                        enabled = module.enabled && filterDetails.count != 0,
+                        enabled = state.areModulesAvailable,
                         onClick = {
                             navTo.invoke(module.route)
                         }
@@ -120,6 +120,14 @@ fun HomeScreen(
             }
         }
     }
+}
+
+/** Resolves the notice to the text shown to the user, or to nothing when there is none. */
+@Composable
+private fun HomeNotice.message(): String? = when (this) {
+    HomeNotice.NONE -> null
+    HomeNotice.SELECT_FILTERS -> stringResource(R.string.home_select_all_filters)
+    HomeNotice.NO_DATA -> stringResource(DesignSystemR.string.no_records_found)
 }
 
 private fun LazyGridScope.fullWidthItem(

--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeUIState.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeUIState.kt
@@ -17,4 +17,23 @@ data class HomeUIState(
     val modules: List<Module> = emptyList(),
     val tei: List<SearchTeiModel> = emptyList(),
     val errorMessage: String? = null
-)
+) {
+
+    /**
+     * Whether the user has told the app which class they are working on.
+     *
+     * This is what opens the modules, not how many learners the class already holds. A class that
+     * has none still has to be reachable, otherwise the first learner could never be enrolled into
+     * it, which offline leaves no way out at all.
+     */
+    val areModulesAvailable: Boolean
+        get() = filterState.isFilterSelectionNotEmpty()
+
+    /** What the screen has to tell the user about the class they picked, if anything. */
+    val notice: HomeNotice
+        get() = when {
+            !areModulesAvailable -> HomeNotice.SELECT_FILTERS
+            filterState.filterDetailsState.count == 0 -> HomeNotice.NO_DATA
+            else -> HomeNotice.NONE
+        }
+}

--- a/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeViewModel.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/presentation/home/HomeViewModel.kt
@@ -207,6 +207,8 @@ class HomeViewModel @Inject constructor(
 
     private fun downloadTei() {
         viewModelScope.launch {
+            // An incomplete selection has nothing to download, and the screen is already showing
+            // the notice that asks for the filters that are still missing.
             if (uiState.value.filterState.isFilterSelectionNotEmpty()) {
                 _uiState.update { it.copy(isLoading = true) }
 
@@ -230,8 +232,6 @@ class HomeViewModel @Inject constructor(
                 }.onFailure { f ->
                     _uiState.update { it.copy(isLoading = false, errorMessage = f.message) }
                 }
-            } else {
-                _uiState.update { it.copy(errorMessage = resourceManager.getString(R.string.apply_filters)) }
             }
         }
     }
@@ -291,7 +291,10 @@ class HomeViewModel @Inject constructor(
                 it.copy(
                     isLoading = true,
                     filterState = lastUpdatedFilterState,
-                    tei = emptyList()
+                    tei = emptyList(),
+                    // The message describes the selection that was in place when it was raised, so
+                    // changing the selection has to retire it or it goes on describing the past.
+                    errorMessage = null
                 )
             }
             updateToolbarHeader(updatedFilterState)

--- a/semis/app/src/main/res/values-pt/strings.xml
+++ b/semis/app/src/main/res/values-pt/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="sync_offline_check_connection">Parece que está offline. Por favor, verifique a sua ligação</string>
     <string name="home_modules">Módulos</string>
+    <string name="home_select_all_filters">Por favor selecione todos os filtros para continuar.</string>
     <string name="home_stat_enrolled">Inscritos</string>
     <string name="home_stat_modules">Módulos</string>
     <string name="home_stat_status">Estado</string>

--- a/semis/app/src/main/res/values/strings.xml
+++ b/semis/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="not_saved">Not saved</string>
     <string name="attendance_not_saved">You have unsaved attendance changes. If you go back now, your data will be discarded.</string>
     <string name="home_modules">Modules</string>
+    <string name="home_select_all_filters">Please select all filters to continue.</string>
     <string name="home_stat_enrolled">Enrolled</string>
     <string name="home_stat_modules">Modules</string>
     <string name="home_stat_status">Status</string>

--- a/semis/app/src/test/java/org/saudigitus/semis/app/presentation/home/HomeUIStateTest.kt
+++ b/semis/app/src/test/java/org/saudigitus/semis/app/presentation/home/HomeUIStateTest.kt
@@ -1,0 +1,73 @@
+package org.saudigitus.semis.app.presentation.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.saudigitus.semis.core.data.model.OrgUnit
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import org.saudigitus.semis.core.designsystem.components.fields.DropdownState
+import org.saudigitus.semis.core.designsystem.components.model.DropdownItem
+import org.saudigitus.semis.core.designsystem.components.model.FilterType
+import org.saudigitus.semis.core.designsystem.filters.FilterComponentState
+
+class HomeUIStateTest {
+
+    @Test
+    fun `modules stay closed while the class is not fully chosen`() {
+        val state = HomeUIState(filterState = filterState(grade = null))
+
+        assertFalse(state.areModulesAvailable)
+        assertEquals(HomeNotice.SELECT_FILTERS, state.notice)
+    }
+
+    @Test
+    fun `modules open once the class is chosen even though it holds no learner`() {
+        val state = HomeUIState(filterState = filterState(count = 0))
+
+        assertTrue(state.areModulesAvailable)
+        assertEquals(HomeNotice.NO_DATA, state.notice)
+    }
+
+    @Test
+    fun `a chosen class that holds learners is reported without a notice`() {
+        val state = HomeUIState(filterState = filterState(count = 12))
+
+        assertTrue(state.areModulesAvailable)
+        assertEquals(HomeNotice.NONE, state.notice)
+    }
+
+    @Test
+    fun `the school alone does not open the modules`() {
+        val state = HomeUIState(
+            filterState = filterState(academicYear = null, grade = null),
+        )
+
+        assertFalse(state.areModulesAvailable)
+        assertEquals(HomeNotice.SELECT_FILTERS, state.notice)
+    }
+
+    /**
+     * Builds a selection over one configured filter, the grade, so that leaving it out reproduces
+     * the case of a user who has answered part of the filters and not the rest.
+     */
+    private fun filterState(
+        academicYear: DropdownItem? = item("2025"),
+        grade: DropdownItem? = item("Grade 1"),
+        count: Int = 0,
+    ): FilterComponentState {
+        val selected = buildMap {
+            academicYear?.let { put(FilterType.ACADEMIC_YEAR, it) }
+            grade?.let { put(FilterType.GRADE, it) }
+        }
+
+        return FilterComponentState(
+            orgUnit = OrgUnit(uid = "ou", displayName = "Albion LBS"),
+            filters = listOf(DropdownState(filterType = FilterType.GRADE)),
+            selectedFilters = selected,
+            filterDetailsState = FilterDetailsState(count = count),
+        )
+    }
+
+    private fun item(name: String) = DropdownItem(id = name, itemName = name, code = name)
+}

--- a/semis/core/data/src/main/assets/appmodules.json
+++ b/semis/core/data/src/main/assets/appmodules.json
@@ -1,17 +1,17 @@
 [
   {
-    "key": "attendance",
-    "title": "Attendance",
-    "enabled": true,
-    "icon": "s_calendar",
-    "route": "attendance"
-  },
-  {
     "key": "enrollment",
     "title": "Enrollment",
     "enabled": true,
     "icon": "enrollment",
     "route": "enrollment"
+  },
+  {
+    "key": "attendance",
+    "title": "Attendance",
+    "enabled": true,
+    "icon": "s_calendar",
+    "route": "attendance"
   },
   {
     "key": "absenteeism",

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppModulesRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppModulesRepositoryImpl.kt
@@ -20,6 +20,21 @@ class AppModulesRepositoryImpl
     val configRepository: AppConfigRepository,
     val resourceManager: ResourceManager
 ) : AppModulesRepository {
+    /**
+     * Reads the modules the home screen offers, in the order they are shown.
+     *
+     * The order follows the life of a learner: enrolled first, marked present day to day, graded,
+     * and eventually transferred. Absenteeism sits beside attendance because it belongs to the same
+     * daily routine.
+     *
+     * That order comes from the bundled asset and is therefore the same on every server, which is
+     * at odds with the rest of SEMIS, where the datastore decides. It should be read from the
+     * datastore too, with the asset kept only as the default, so that a deployment can present the
+     * modules in the order its own users work in. That change is not made here.
+     *
+     * A module the configuration disables is dropped from the list rather than shown as
+     * unavailable, so what this returns is exactly what the home screen draws.
+     */
     override suspend fun getModules(program: String) = withContext(Dispatchers.IO) {
         val appConfig = configRepository.getAppConfig(program)
 

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/NotFound.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/NotFound.kt
@@ -2,6 +2,7 @@ package org.saudigitus.semis.core.designsystem.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,7 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.HideSource
+import androidx.compose.material.icons.rounded.WarningAmber
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -33,6 +34,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.saudigitus.semis.core.designsystem.R
 import org.saudigitus.semis.core.designsystem.theme.dark_warning
+import org.saudigitus.semis.core.designsystem.theme.warning_notice_content
+import org.saudigitus.semis.core.designsystem.theme.warning_notice_outline
+import org.saudigitus.semis.core.designsystem.theme.warning_notice_surface
 
 @Composable
 fun ConfigNotFound(
@@ -69,33 +73,46 @@ fun ConfigNotFound(
     }
 }
 
+/**
+ * Banner telling the user what is missing before the screen can be of any use.
+ *
+ * It warns rather than blocks, so it is drawn as a notice and not as an error: a warm surface, a
+ * quiet outline and text small enough to read as a remark beside the content rather than as an
+ * interruption of it. The icon sits after the text because the message is what has to be read
+ * first, and the icon only says how to read it.
+ */
 @Composable
 fun NoRecordsFound(
     modifier: Modifier = Modifier,
-    imageVector: ImageVector = Icons.Default.HideSource,
+    imageVector: ImageVector = Icons.Rounded.WarningAmber,
     message: String = stringResource(R.string.no_records_found)
 ) {
     Row(
-        modifier = modifier.then(
-            Modifier.background(
-                color = Color.LightGray.copy(alpha = .25f),
-                shape = RoundedCornerShape(16.dp)
-            ).padding(16.dp)
-        ),
-        horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
+        modifier = modifier
+            .background(color = warning_notice_surface, shape = NoticeShape)
+            .border(width = 1.dp, color = warning_notice_outline, shape = NoticeShape)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = stringResource(R.string.no_records_found),
-            tint = dark_warning
-        )
         Text(
+            modifier = Modifier.weight(1f),
             text = message,
-            color = dark_warning
+            color = warning_notice_content,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            fontFamily = FontFamily(Font(R.font.rubik_regular)),
+        )
+        Icon(
+            modifier = Modifier.size(20.dp),
+            imageVector = imageVector,
+            contentDescription = null,
+            tint = warning_notice_content
         )
     }
 }
+
+private val NoticeShape = RoundedCornerShape(12.dp)
 
 
 @Composable

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/Color.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/theme/Color.kt
@@ -226,4 +226,13 @@ val light_error = Color(0xFFE57373)
 
 val dark_warning = Color(0xFFFD9600)
 
+/**
+ * The three tones of a warning notice: a banner that tells the user what is missing without
+ * blocking them. Kept as a set so the surface, its edge and what is written on it always come from
+ * the same family and the contrast between them is decided once.
+ */
+val warning_notice_surface = Color(0xFFFFEDD5)
+val warning_notice_outline = Color(0xFFFFC98A)
+val warning_notice_content = Color(0xFF8A4B00)
+
 val white = 0xFFFFFFFF

--- a/semis/core/designsystem/src/main/res/values-pt/strings.xml
+++ b/semis/core/designsystem/src/main/res/values-pt/strings.xml
@@ -9,8 +9,7 @@
     <string name="filters">Filtros</string>
     <string name="back">Voltar</string>
     <string name="config_not_found">Aplicação não configurada, por favor contacte o Administrador do Sistema.</string>
-    <string name="no_records_found">Sem registos. Actualize os filtros e/ou sincronize os dados.</string>
-    <string name="apply_filters">Para começar a transferir os estudantes, selecione os seus filtros (por exemplo, escola, ano ou ano lectivo).\nIsto ajuda-nos a obter apenas os dados de que precisa.</string>
+    <string name="no_records_found">Sem registos. Actualize os filtros, sincronize os dados ou adicione uma nova inscrição.</string>
 
     <string name="not_synced">Não sincronizado</string>
     <string name="programs">Programas</string>

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -9,8 +9,7 @@
     <string name="filters">Filters</string>
     <string name="back">Back</string>
     <string name="config_not_found">App not configured, please contact System Administrator.</string>
-    <string name="no_records_found">No records, please update your filters and/or sync data</string>
-    <string name="apply_filters">To start downloading students, please select your filters (e.g., school, grade, or year).\nThis helps us fetch only the data you need.</string>
+    <string name="no_records_found">No records, please update your filters, sync data or add a new enrollment.</string>
 
     <string name="not_synced">Not synced</string>
     <string name="programs">Programs</string>


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-150).

### Problem

The module cards on the home screen were enabled only when the current filter selection had already returned at least one learner. Any selection returning none left every card disabled, including Enrollment.

That makes a school starting from zero unable to register anybody: Enrollment is the module that would create the first record, and it is disabled precisely because no record exists yet. With a connection this is merely awkward, since syncing brings learners in and unlocks the cards. Offline it is a dead end, and the class stays empty for as long as the connection is missing.

The same condition also decided whether the message area was shown, so an incomplete selection and a complete selection over an empty class were treated as the same situation even though they ask different things of the user. The message itself was never cleared once set, so it went on describing a state the user had already left.

The order of the cards was inherited from the order the modules happened to be written into the bundled asset. It followed no workflow.

### Solution

- Enable the cards from the filter selection instead of the learner count. Once the user has said which class they are working on, meaning school, academic year and every configured filter, the modules are theirs to open, whether or not the class already holds anyone.
- Drop the module enabled flag from the condition. Modules the configuration disables are removed from the list before it reaches the screen, so the flag was always true there and only suggested a check that was not happening.
- Split the message into two states of its own, derived on the state rather than resolved in the view model: one asking for the filters that are still missing, one reporting that the selection holds no records. Retire the message whenever the selection changes.
- Order the cards by the life of a learner: Enrollment, Attendance, Absenteeism, Performance, Transfer. Absenteeism sits beside Attendance because it belongs to the same daily routine, and stays hidden while it is disabled.
- Draw the notice as a warning banner: a warm surface, an outline a shade deeper, smaller text and the icon after the message. The three tones are kept together as a set in the palette so the contrast between them is decided once.

### Note for the reviewer

The order still comes from the bundled asset and is therefore the same on every server, which is at odds with the rest of SEMIS, where the datastore decides. This is documented where the modules are read and left for its own ticket.

`no_records_found` is shared with the Attendance, Performance, tracked entity list and Enrollment screens, so its new wording appears there too. It still reads correctly on all of them, since each shows a list of learners, but it can be split into a home specific string if that is preferred.

### Validation

- Unit test sweep over the nine SEMIS modules: 97 tests, 0 failures, up from 93. The four new cases cover the derived state: an incomplete selection, a complete selection over an empty class, a class holding learners, and a school chosen on its own.
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- Both states exercised on the emulator. With the filters incomplete the cards are disabled and the banner asks for them. With school, year, grade and section chosen and **no learners at all**, the four cards are enabled, and opening Enrollment from there reaches the listing with its new enrollment action, which is what was impossible before.