### PR TITLE
fix: [SEMIS-154] attendance can be taken on days the school calendar declares non-teaching

### DIFF
--- a/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
+++ b/semis/app/src/main/java/org/saudigitus/semis/app/AppNavGraph.kt
@@ -109,7 +109,8 @@ fun AppNavGraph(
                     homeState.program,
                     homeState.filterState.orgUnit?.uid.orEmpty(),
                     homeState.tei,
-                    homeState.filterState.filterDetailsState
+                    homeState.filterState.filterDetailsState,
+                    homeState.filterState.getAcademicYearSelection()?.code,
                 )
             }
 

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -45,6 +45,12 @@ class AttendanceViewModel @Inject constructor(
     private var selectedDate: String = DateHelper.formatDate(System.currentTimeMillis())
         .orEmpty()
 
+    /**
+     * The academic year the user is working in, which decides whose calendar judges the dates.
+     * Left null until the screen is initialised, where the configured default stands in.
+     */
+    private var academicYearCode: String? = null
+
     private var cachedButtonModel: AttendanceButtonModel? = null
 
     private val _hasCachedData = MutableStateFlow(false)
@@ -82,11 +88,16 @@ class AttendanceViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     dateValidator = { date ->
-                        appConfigRepository.allowedCalenderYearDates(date, schoolCalendar)
+                        appConfigRepository.allowedCalenderYearDates(
+                            date,
+                            schoolCalendar,
+                            academicYearCode,
+                        )
                     },
                     canTakeAttendance = appConfigRepository.allowedCalenderYearDates(
                         DateHelper.convertDateToMilliseconds(selectedDate),
-                        schoolCalendar
+                        schoolCalendar,
+                        academicYearCode,
                     )
                 )
             }
@@ -99,10 +110,12 @@ class AttendanceViewModel @Inject constructor(
         program: String,
         orgUnit: String,
         teis: List<SearchTeiModel>,
-        filterDetailsState: FilterDetailsState
+        filterDetailsState: FilterDetailsState,
+        academicYearCode: String? = null,
     ) {
         viewModelScope.launch {
             studentsIds = teis.mapNotNull { it.tei.uid() }
+            this@AttendanceViewModel.academicYearCode = academicYearCode
 
             val config = appConfigRepository.getAppConfig(program)
             attendanceConfig = config?.attendance
@@ -192,7 +205,8 @@ class AttendanceViewModel @Inject constructor(
                 ),
                 canTakeAttendance = appConfigRepository.allowedCalenderYearDates(
                     DateHelper.convertDateToMilliseconds(selectedDate),
-                    schoolCalendar
+                    schoolCalendar,
+                    academicYearCode,
                 )
             )
         }

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
@@ -93,7 +93,7 @@ class AttendanceResetTest {
                 trackedEntityType = null,
                 transfer = null,
             )
-            onBlocking { allowedCalenderYearDates(any(), any()) } doReturn true
+            onBlocking { allowedCalenderYearDates(any(), any(), anyOrNull()) } doReturn true
         }
 
         return AttendanceViewModel(

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/schoolcalendar_config/SchoolDayRules.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/schoolcalendar_config/SchoolDayRules.kt
@@ -1,0 +1,89 @@
+package org.saudigitus.semis.core.data.model.schoolcalendar_config
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+/**
+ * The calendar of a given academic year, or of the one the configuration names as its default.
+ *
+ * Which year is asked for matters: a user working in an earlier year has to be judged by that
+ * year's teaching days, holidays and span, not by this year's. Falling back to the default only
+ * when nothing is selected keeps the screens that do not track a selection working as before.
+ */
+fun SchoolCalendarConfig?.calendarOfYear(academicYearCode: String?): SchoolCalendar? {
+    val config = this ?: return null
+    val wanted = academicYearCode?.takeIf { it.isNotBlank() }
+        ?: config.defaults?.academicYear
+
+    return config.schoolCalendar
+        ?.filterNotNull()
+        ?.firstOrNull { it.academicYear?.code == wanted }
+}
+
+/**
+ * Whether a day may carry attendance under a school's calendar.
+ *
+ * A day qualifies when the school teaches on it, it is not a holiday, it falls inside the
+ * academic year and it has already happened. Each of those is only applied where the calendar
+ * says something about it: a calendar that lists no holidays is a school with none to exclude,
+ * and one without a start or an end is a year that does not bound the choice. Configuration that
+ * is absent must not be read as configuration that forbids.
+ *
+ * The one rule that holds regardless is the future: attendance cannot be taken for a day that has
+ * not happened, whatever a calendar says or fails to say.
+ */
+fun isSchoolDay(
+    date: LocalDate,
+    today: LocalDate,
+    calendar: SchoolCalendar?,
+): Boolean {
+    if (date.isAfter(today)) return false
+    if (calendar == null) return true
+
+    if (!calendar.teachesOn(date.dayOfWeek)) return false
+    if (calendar.isHoliday(date)) return false
+
+    return date.withinAcademicYear(calendar.academicYear)
+}
+
+/**
+ * Whether the school teaches on this day of the week.
+ *
+ * A calendar with no week configured at all does not restrict the week, since saying nothing is
+ * not the same as saying no. Once the week is configured it is taken as the whole answer, so a
+ * day it does not mark as teaching is a day the school does not teach.
+ */
+private fun SchoolCalendar.teachesOn(day: DayOfWeek): Boolean {
+    val week = weekDays ?: return true
+
+    return when (day) {
+        DayOfWeek.MONDAY -> week.monday
+        DayOfWeek.TUESDAY -> week.tuesday
+        DayOfWeek.WEDNESDAY -> week.wednesday
+        DayOfWeek.THURSDAY -> week.thursday
+        DayOfWeek.FRIDAY -> week.friday
+        DayOfWeek.SATURDAY -> week.saturday
+        DayOfWeek.SUNDAY -> week.sunday
+    } == true
+}
+
+/** Whether the date is one of the holidays the calendar lists. */
+private fun SchoolCalendar.isHoliday(date: LocalDate): Boolean {
+    val wanted = date.toString()
+
+    return holidays.orEmpty()
+        .filterNotNull()
+        .any { it.date == wanted }
+}
+
+/** Whether the date falls inside the year, where the year says where it starts and ends. */
+private fun LocalDate.withinAcademicYear(academicYear: AcademicYear?): Boolean {
+    val start = academicYear?.startDate?.toLocalDateOrNull()
+    val end = academicYear?.endDate?.toLocalDateOrNull()
+
+    return (start == null || !isBefore(start)) && (end == null || !isAfter(end))
+}
+
+private fun String.toLocalDateOrNull(): LocalDate? = runCatching {
+    LocalDate.parse(takeIf { it.isNotBlank() })
+}.getOrNull()

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppConfigRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppConfigRepository.kt
@@ -6,6 +6,16 @@ import org.saudigitus.semis.core.data.model.schoolcalendar_config.SchoolCalendar
 interface AppConfigRepository {
     suspend fun getAppConfig(program: String): SEMISConfigItem?
     suspend fun getSchoolCalendar(): SchoolCalendarConfig?
-    fun allowedCalenderYearDates(dateLong: Long, schoolCalendar: SchoolCalendarConfig?): Boolean
+    /**
+     * Whether a day may carry attendance, judged by the calendar of [academicYearCode].
+     *
+     * The year is asked for rather than assumed, because a user working in an earlier year has to
+     * be judged by that year's calendar. Where nothing is selected the configured default stands.
+     */
+    fun allowedCalenderYearDates(
+        dateLong: Long,
+        schoolCalendar: SchoolCalendarConfig?,
+        academicYearCode: String? = null,
+    ): Boolean
 }
 

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppConfigRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/AppConfigRepositoryImpl.kt
@@ -1,20 +1,19 @@
 package org.saudigitus.semis.core.data.repository
 
-import androidx.compose.ui.util.fastFilterNotNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.D2
 import org.saudigitus.semis.core.data.model.app_config.SEMISConfig
-import org.saudigitus.semis.core.data.model.schoolcalendar_config.Holiday
+import org.saudigitus.semis.core.data.model.schoolcalendar_config.calendarOfYear
+import org.saudigitus.semis.core.data.model.schoolcalendar_config.isSchoolDay
 import org.saudigitus.semis.core.data.model.schoolcalendar_config.SchoolCalendarConfig
 import org.saudigitus.semis.core.utils.Constants.CALENDAR_KEY
 import org.saudigitus.semis.core.utils.Constants.DATASTORE_KEY
 import org.saudigitus.semis.core.utils.Constants.DATASTORE_NAMESPACE
-import org.saudigitus.semis.core.utils.DateHelper
-import org.saudigitus.semis.core.utils.DateHelper.formatDate
-import org.saudigitus.semis.core.utils.DateHelper.stringToLocalDate
 import org.saudigitus.semis.core.utils.JsonMapper
 import org.saudigitus.semis.core.utils.decodeJson
+import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import javax.inject.Inject
 
@@ -48,41 +47,13 @@ class AppConfigRepositoryImpl
         return@withContext calendarConfig
     }
 
-    override fun allowedCalenderYearDates(dateLong: Long, schoolCalendar: SchoolCalendarConfig?): Boolean {
-        val default = schoolCalendar?.defaults
-        val currentSchoolCalendar = schoolCalendar?.schoolCalendar?.find {
-            it?.academicYear?.code == default?.academicYear
-        }
-
-        val date = stringToLocalDate(formatDate(dateLong)!!)
-        val today = System.currentTimeMillis()
-
-        return if (schoolCalendar != null && currentSchoolCalendar != null) {
-            val startDate = currentSchoolCalendar.academicYear?.startDate
-            val endDate = currentSchoolCalendar.academicYear?.endDate
-
-            val startMillis = stringToLocalDate(startDate!!)
-                .atStartOfDay(ZoneId.systemDefault())
-                ?.toInstant()?.toEpochMilli()!!
-            val endMillis = stringToLocalDate(endDate!!)
-                .atStartOfDay(ZoneId.systemDefault())
-                ?.toInstant()?.toEpochMilli()!!
-
-            (
-                !DateHelper.isWeekend(date) && currentSchoolCalendar.weekDays?.saturday == false &&
-                    currentSchoolCalendar.weekDays.sunday == false
-                ) &&
-                currentSchoolCalendar.holidays?.let { holiday ->
-                    isHoliday(holiday.fastFilterNotNull(), dateLong)
-                } == true && (dateLong in startMillis..endMillis) && dateLong <= today
-        } else {
-            dateLong <= today
-        }
-    }
-
-    private fun isHoliday(holidays: List<Holiday>, date: Long): Boolean {
-        return holidays.none { holiday ->
-            holiday.date == formatDate(date)
-        }
-    }
+    override fun allowedCalenderYearDates(
+        dateLong: Long,
+        schoolCalendar: SchoolCalendarConfig?,
+        academicYearCode: String?,
+    ): Boolean = isSchoolDay(
+        date = Instant.ofEpochMilli(dateLong).atZone(ZoneId.systemDefault()).toLocalDate(),
+        today = LocalDate.now(),
+        calendar = schoolCalendar.calendarOfYear(academicYearCode),
+    )
 }

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/schoolcalendar_config/SchoolDayRulesTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/schoolcalendar_config/SchoolDayRulesTest.kt
@@ -1,0 +1,159 @@
+package org.saudigitus.semis.core.data.model.schoolcalendar_config
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class SchoolDayRulesTest {
+
+    private val today = LocalDate.parse("2025-07-31")
+
+    private val monToWed = WeekDays(
+        monday = true,
+        tuesday = true,
+        wednesday = true,
+        thursday = false,
+        friday = false,
+        saturday = false,
+        sunday = false,
+    )
+
+    private val calendar = SchoolCalendar(
+        id = "cal-2025",
+        academicYear = AcademicYear(
+            code = "2025",
+            label = "2025",
+            description = "2025",
+            startDate = "2025-01-01",
+            endDate = "2025-12-31",
+        ),
+        classPeriods = emptyList(),
+        holidays = listOf(Holiday(date = "2025-05-01", event = "Workers Day", type = "public")),
+        weekDays = monToWed,
+    )
+
+    @Test
+    fun `a day the school teaches on is allowed`() {
+        // 2025-07-09 is a Wednesday
+        assertTrue(isSchoolDay(LocalDate.parse("2025-07-09"), today, calendar))
+    }
+
+    @Test
+    fun `a day the school does not teach on is refused`() {
+        // 2025-07-10 is a Thursday, which this school does not teach on
+        assertFalse(isSchoolDay(LocalDate.parse("2025-07-10"), today, calendar))
+    }
+
+    @Test
+    fun `a weekend the school does teach on is allowed`() {
+        val teachesSaturday = calendar.copy(weekDays = monToWed.copy(saturday = true))
+
+        // 2025-07-12 is a Saturday
+        assertTrue(isSchoolDay(LocalDate.parse("2025-07-12"), today, teachesSaturday))
+    }
+
+    @Test
+    fun `a holiday is refused even though the school teaches that weekday`() {
+        // 2025-05-01 is a Thursday, so make the school teach it to isolate the holiday
+        val teachesThursday = calendar.copy(weekDays = monToWed.copy(thursday = true))
+
+        assertFalse(isSchoolDay(LocalDate.parse("2025-05-01"), today, teachesThursday))
+    }
+
+    @Test
+    fun `a calendar listing no holidays excludes nothing`() {
+        val noHolidays = calendar.copy(holidays = null)
+
+        assertTrue(isSchoolDay(LocalDate.parse("2025-07-09"), today, noHolidays))
+    }
+
+    @Test
+    fun `a calendar with no week configured does not restrict the week`() {
+        val noWeek = calendar.copy(weekDays = null)
+
+        assertTrue(isSchoolDay(LocalDate.parse("2025-07-10"), today, noWeek))
+    }
+
+    @Test
+    fun `a date outside the academic year is refused`() {
+        assertFalse(isSchoolDay(LocalDate.parse("2024-12-31"), today, calendar))
+    }
+
+    @Test
+    fun `a calendar without a start or an end does not bound the choice`() {
+        val unbounded = calendar.copy(
+            academicYear = calendar.academicYear?.copy(startDate = null, endDate = null),
+        )
+
+        assertTrue(isSchoolDay(LocalDate.parse("2019-01-07"), today, unbounded))
+    }
+
+    @Test
+    fun `a day that has not happened is refused whatever the calendar says`() {
+        val everyDay = calendar.copy(
+            weekDays = null,
+            holidays = null,
+            academicYear = calendar.academicYear?.copy(startDate = null, endDate = null),
+        )
+
+        assertFalse(isSchoolDay(today.plusDays(1), today, everyDay))
+        assertFalse(isSchoolDay(today.plusDays(1), today, null))
+    }
+
+    @Test
+    fun `today itself is allowed`() {
+        // 2025-07-31 is a Thursday, so make the school teach it
+        val teachesThursday = calendar.copy(weekDays = monToWed.copy(thursday = true))
+
+        assertTrue(isSchoolDay(today, today, teachesThursday))
+    }
+
+    @Test
+    fun `no calendar at all leaves only the rule about the future`() {
+        assertTrue(isSchoolDay(LocalDate.parse("2025-07-10"), today, null))
+    }
+
+    @Test
+    fun `the calendar of the selected year is the one that answers`() {
+        val config = SchoolCalendarConfig(
+            academicYear = "de",
+            defaults = Defaults(academicYear = "2025"),
+            schoolCalendar = listOf(calendar, calendar.copy(id = "cal-2024", academicYear = AcademicYear(
+                code = "2024",
+                label = "2024",
+                description = "2024",
+                startDate = "2024-01-01",
+                endDate = "2024-12-31",
+            ))),
+        )
+
+        assertEquals("cal-2024", config.calendarOfYear("2024")?.id)
+        assertEquals("cal-2025", config.calendarOfYear("2025")?.id)
+    }
+
+    @Test
+    fun `the configured default answers when no year is selected`() {
+        val config = SchoolCalendarConfig(
+            academicYear = "de",
+            defaults = Defaults(academicYear = "2025"),
+            schoolCalendar = listOf(calendar),
+        )
+
+        assertEquals("cal-2025", config.calendarOfYear(null)?.id)
+        assertEquals("cal-2025", config.calendarOfYear("")?.id)
+    }
+
+    @Test
+    fun `a year with no calendar of its own resolves to nothing`() {
+        val config = SchoolCalendarConfig(
+            academicYear = "de",
+            defaults = Defaults(academicYear = "2025"),
+            schoolCalendar = listOf(calendar),
+        )
+
+        assertNull(config.calendarOfYear("2019"))
+    }
+}


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-154).

### Problem

The school calendar states which days of the week a school teaches on, its holidays and the span of the academic year. The check that decided whether a date could carry attendance read only two of those seven days, Saturday and Sunday, and required both to be off.

On an instance teaching Monday to Wednesday, every Thursday and Friday stayed selectable and attendance taken on one was recorded as an ordinary school day. Reproduced on the running server: `Thursday, Jul 10, 2025` was offered, chosen and accepted.

The same rule failed in the other direction too:

- a school teaching on Saturday had **every** day refused rather than one more allowed, since the check demanded Saturday be off
- a school with no holidays listed had **every** day refused, since a missing list was read as no date being valid
- the holiday helper returned true when a date was *not* a holiday, which the caller happened to compensate for and the next reader would not have
- the start and end of the academic year were read without guarding their absence, so a calendar without them stopped the screen

Separately, the calendar consulted was always the one the configuration names as its default. A user working in an earlier year had their dates judged by this year's teaching days, holidays and span.

### Solution

- Decide from the whole week the calendar configures, not from Saturday and Sunday alone.
- Read the calendar of the academic year the user selected, carried in from the selection, falling back to the configured default only where nothing is selected.
- Treat what the calendar does not say as nothing forbidden: no holidays listed excludes nothing, no week configured does not restrict the week, no start or end does not bound the choice. Configuration that is absent must not be read as configuration that refuses, which is how a school with no holidays came to have no school days.
- Keep refusing dates in the future under every path. It is the one rule that holds even when the calendar says nothing at all.
- Name the holiday check for what it answers.

The decision now lives in a pure function taking the date, today and the calendar, which is what let it be covered case by case.

### Validation

- Unit test sweep over the nine SEMIS modules: 107 tests, 0 failures, up from 93. The 14 new cases cover a teaching day, a non-teaching day, a weekend the school does teach on, a holiday, a calendar with no holidays, one with no week, one without dates, a date outside the year, a date in the future, today itself, no calendar at all, and the resolution of the selected year against the configured default.
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- On the emulator against the live server, August 2025 now offers only 4, 5, 6, 11, 12, 13, 18, 19, 20, 25, 26 and 27, which are its Mondays, Tuesdays and Wednesdays. Before this, the 7th and 8th, a Thursday and a Friday, were offered.

### Note for the reviewer

`AttendanceResetTest` stubbed the check with two arguments and now stubs three. That is the double following the signature, not a change of behaviour.

This is the same family of defect as [SEMIS-153](https://dhis2.atlassian.net/browse/SEMIS-153): the academic year the user selected was not reaching the code that decided with it. There it was the learner search and the local count, here it is the date validation. The two branches share no file and can be merged in either order.