### PR TITLE
refactor: [SEMIS-155] give the attendance screen the header and notices the rest of SEMIS uses

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.saudigitus.semis.attendance.ui.components.AttendanceBulkBar
+import org.saudigitus.semis.attendance.ui.components.AttendanceClassSummary
 import org.saudigitus.semis.attendance.ui.components.AttendanceCompletionNotice
 import org.saudigitus.semis.attendance.ui.components.AttendanceHeader
 import org.saudigitus.semis.attendance.ui.components.AttendanceSaveBar
@@ -96,14 +97,6 @@ fun AttendanceScreen(
         header = {
             AttendanceHeader(
                 headers = state.toolbarHeaders,
-                tiles = attendanceStatTiles(
-                    totalLabel = stringResource(AttendanceRes.string.attendance_total),
-                    totalLearners = state.teis.size,
-                    summaries = state.attendanceSummaryState.bottomSheetModels,
-                    hasAttendanceRecord = state.hasAttendanceRecord,
-                ),
-                pendingSyncCount = state.pendingSyncCount,
-                filterDetailsState = state.attendanceSummaryState.filterDetailsState,
                 dateValidator = { state.dateValidator(it) },
                 onNavigateBack = { onEvent(AttendanceUiEvent.NavBack) },
                 onSync = { onEvent(AttendanceUiEvent.OnSyncClicked) },
@@ -154,6 +147,17 @@ fun AttendanceScreen(
             )
         },
     ) {
+        AttendanceClassSummary(
+            filterDetailsState = state.attendanceSummaryState.filterDetailsState,
+            totalLearners = state.teis.size,
+            tiles = attendanceStatTiles(
+                totalLabel = stringResource(AttendanceRes.string.attendance_total),
+                totalLearners = state.teis.size,
+                summaries = state.attendanceSummaryState.bottomSheetModels,
+                hasAttendanceRecord = state.hasAttendanceRecord,
+            ),
+        )
+
         if (isEditing) {
             AttendanceBulkBar(
                 buttons = formState.attendanceButtonState.buttons,

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceClassSummary.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceClassSummary.kt
@@ -1,0 +1,116 @@
+package org.saudigitus.semis.attendance.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.saudigitus.semis.attendance.R
+import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
+import org.saudigitus.semis.core.designsystem.components.stats.StatTileModel
+import org.saudigitus.semis.core.designsystem.components.stats.StatTileRow
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
+
+/**
+ * Says which class is on screen and how the day is going, on the sheet below the header.
+ *
+ * Laid out as the performance capture screen lays out its own summary, so that two screens
+ * doing the same job, naming a class and tallying it, are read the same way. The school
+ * takes the place performance gives to the subject, being what names the group here.
+ *
+ * The tiles keep the colour of the status they count, unlike performance where the numbers
+ * are neutral: presence and absence are read at a glance and losing that would cost more
+ * than the calm it buys.
+ */
+@Composable
+internal fun AttendanceClassSummary(
+    filterDetailsState: FilterDetailsState,
+    tiles: List<StatTileModel>,
+    totalLearners: Int,
+    modifier: Modifier = Modifier,
+) {
+    // The header colour is painted behind the sheet so that the rounded top corners have
+    // something to curve over. Without it the corners fall on the screen background and the
+    // seam between the two reads as a straight cut. It has to be the colour the bar itself
+    // uses, or the two blues meet and the join is visible as a band.
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(SemisPalette.HeaderBlueAccent),
+    ) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = SummarySheetShape,
+        color = SemisPalette.CardSurface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        modifier = Modifier.weight(1f),
+                        text = filterDetailsState.orgUnit,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = SemisPalette.TextPrimary,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.attendance_students_count,
+                            totalLearners,
+                            totalLearners,
+                        ),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = SemisPalette.TextSecondary,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+
+                val context = listOfNotNull(
+                    filterDetailsState.grade,
+                    filterDetailsState.section,
+                    filterDetailsState.academicYear,
+                ).filter { it.isNotBlank() }.joinToString(separator = " · ")
+
+                if (context.isNotBlank()) {
+                    Text(
+                        text = context,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = SemisPalette.TextSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            StatTileRow(tiles = tiles)
+        }
+    }
+    }
+}
+
+/** Curves over the header, which is flat where the two meet. */
+private val SummarySheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceHeader.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/components/AttendanceHeader.kt
@@ -1,97 +1,57 @@
 package org.saudigitus.semis.attendance.ui.components
 
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.Sync
-import androidx.compose.material.icons.filled.SyncProblem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import org.saudigitus.semis.attendance.R
-import org.saudigitus.semis.core.designsystem.components.CustomDatePicker
-import org.saudigitus.semis.core.designsystem.components.FilterDetailsState
-import org.saudigitus.semis.core.designsystem.components.buttons.TonalIconButton
-import org.saudigitus.semis.core.designsystem.components.filters.FilterDetailsInfoCard
-import org.saudigitus.semis.core.designsystem.components.header.HeaderTitleBar
-import org.saudigitus.semis.core.designsystem.components.header.RoundedBottomHeader
+import androidx.compose.ui.graphics.Color
+import org.saudigitus.semis.core.designsystem.components.Toolbar
+import org.saudigitus.semis.core.designsystem.components.ToolbarActionState
 import org.saudigitus.semis.core.designsystem.components.model.ToolbarHeaders
-import org.saudigitus.semis.core.designsystem.components.pills.StatusPill
-import org.saudigitus.semis.core.designsystem.components.stats.StatTileModel
-import org.saudigitus.semis.core.designsystem.components.stats.StatTileRow
-
-/** Shared height of the header actions, so the sync pill and the calendar button align. */
-private val HeaderActionHeight = 32.dp
+import org.saudigitus.semis.core.designsystem.theme.SemisPalette
 
 /**
- * Attendance screen header: navigation, the selected date, the synchronization state, the
- * live status counters and the filter context the list is scoped to.
+ * Attendance screen header.
+ *
+ * The same bar the home, the listings and the performance screens are given by their own
+ * scaffold, with the same colour, the same title and the same placing of the actions.
+ * Attendance used to build a header of its own, which is why it looked like a screen from a
+ * different app.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun AttendanceHeader(
     headers: ToolbarHeaders,
-    tiles: List<StatTileModel>,
-    pendingSyncCount: Int,
-    filterDetailsState: FilterDetailsState,
     modifier: Modifier = Modifier,
     dateValidator: (Long) -> Boolean = { true },
     onNavigateBack: () -> Unit,
     onSync: () -> Unit,
     onDateSelected: (String) -> Unit,
 ) {
-    var isCalendarShown by remember { mutableStateOf(false) }
-
-    CustomDatePicker(
-        show = isCalendarShown,
-        dismiss = { isCalendarShown = false },
-        onDatePick = onDateSelected,
-        dateValidator = dateValidator,
-    )
-
-    RoundedBottomHeader(
+    Toolbar(
         modifier = modifier,
-        verticalSpacing = 12.dp,
-    ) {
-        HeaderTitleBar(
-            title = headers.title,
-            subtitle = headers.subtitle,
-            onNavigateBack = onNavigateBack,
-            onSubtitleClick = { isCalendarShown = true },
-            trailing = {
-                StatusPill(
-                    text = if (pendingSyncCount > 0) {
-                        stringResource(R.string.attendance_unsynced_count, pendingSyncCount)
-                    } else {
-                        stringResource(R.string.attendance_synced)
-                    },
-                    imageVector = if (pendingSyncCount > 0) {
-                        Icons.Default.SyncProblem
-                    } else {
-                        Icons.Default.Sync
-                    },
-                    modifier = Modifier.height(HeaderActionHeight),
-                    onClick = onSync,
-                )
-
-                TonalIconButton(
-                    imageVector = Icons.Default.CalendarMonth,
-                    contentDescription = stringResource(R.string.select_attendance_date),
-                    size = HeaderActionHeight,
-                    iconSize = 17.dp,
-                    shape = RoundedCornerShape(10.dp),
-                    onClick = { isCalendarShown = true },
-                )
-            },
-        )
-
-        FilterDetailsInfoCard(state = filterDetailsState)
-
-        StatTileRow(tiles = tiles)
-    }
+        headers = headers,
+        colors = AttendanceToolbarColors,
+        navigationAction = onNavigateBack,
+        disableNavigation = false,
+        actionState = ToolbarActionState(
+            syncVisibility = true,
+            filterVisibility = false,
+            showCalendar = true,
+        ),
+        calendarAction = onDateSelected,
+        dateValidator = dateValidator,
+        syncAction = onSync,
+    )
 }
+
+/** The colours every other SEMIS screen gives its bar, taken from the shared scaffold. */
+@OptIn(ExperimentalMaterial3Api::class)
+private val AttendanceToolbarColors: TopAppBarColors
+    @Composable get() = TopAppBarDefaults.topAppBarColors(
+        containerColor = SemisPalette.HeaderBlueAccent,
+        navigationIconContentColor = Color.White,
+        titleContentColor = Color.White,
+        actionIconContentColor = Color.White,
+    )

--- a/semis/attendance/src/main/res/values/strings.xml
+++ b/semis/attendance/src/main/res/values/strings.xml
@@ -9,9 +9,13 @@
     <string name="attendance_synced">Synced</string>
     <string name="attendance_unsynced_count">%1$d unsynced</string>
     <string name="attendance_all_recorded">All students recorded</string>
-    <string name="attendance_not_recorded">No attendance has been recorded for this day yet.</string>
+    <plurals name="attendance_students_count">
+        <item quantity="one">%1$d student</item>
+        <item quantity="other">%1$d students</item>
+    </plurals>
+    <string name="attendance_not_recorded">No records, please take attendance!</string>
     <string name="attendance_reset_warning">Resetting deletes the attendance already recorded for this day. This cannot be undone.</string>
-    <string name="attendance_completed">Attendance completed for this day</string>
+    <string name="attendance_completed">Attendance completed</string>
     <string name="attendance_incomplete">Incomplete attendance</string>
     <string name="select_attendance_date">Select attendance date</string>
     <string name="reset_attendance">Reset attendance</string>

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/TopAppBar.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/TopAppBar.kt
@@ -164,19 +164,19 @@ fun Toolbar(
             }
         },
         actions = {
-            if (actionState.showCalendar) {
-                IconButton(onClick = { isCalendarShown = !isCalendarShown }) {
-                    Icon(
-                        imageVector = Icons.Default.CalendarMonth,
-                        contentDescription = stringResource(R.string.calendar),
-                    )
-                }
-            }
             if (actionState.syncVisibility) {
                 IconButton(onClick = { syncAction.invoke() }) {
                     Icon(
                         imageVector = Icons.Default.Sync,
                         contentDescription = stringResource(R.string.sync),
+                    )
+                }
+            }
+            if (actionState.showCalendar) {
+                IconButton(onClick = { isCalendarShown = !isCalendarShown }) {
+                    Icon(
+                        imageVector = Icons.Default.CalendarMonth,
+                        contentDescription = stringResource(R.string.calendar),
                     )
                 }
             }

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/buttons/TonalIconButton.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/buttons/TonalIconButton.kt
@@ -1,11 +1,13 @@
 package org.saudigitus.semis.core.designsystem.components.buttons
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -34,15 +36,23 @@ fun TonalIconButton(
     IconButton(
         onClick = onClick,
         enabled = enabled,
-        modifier = modifier
-            .size(size)
-            .background(color = containerColor, shape = shape),
+        modifier = modifier.size(size),
     ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = contentDescription,
-            tint = contentColor,
-            modifier = Modifier.size(iconSize),
-        )
+        // The tint is painted inside rather than on the button itself: a button of this size
+        // is widened to stay comfortable to tap, and a background set on the outside is drawn
+        // over that wider area, which makes two of them side by side look like one.
+        Box(
+            modifier = Modifier
+                .size(size)
+                .background(color = containerColor, shape = shape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                tint = contentColor,
+                modifier = Modifier.size(iconSize),
+            )
+        }
     }
 }

--- a/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/notice/InlineNotice.kt
+++ b/semis/core/designsystem/src/main/java/org/saudigitus/semis/core/designsystem/components/notice/InlineNotice.kt
@@ -1,7 +1,6 @@
 package org.saudigitus.semis.core.designsystem.components.notice
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,11 +19,14 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.saudigitus.semis.core.designsystem.R
-import org.saudigitus.semis.core.designsystem.theme.borderTone
 import org.saudigitus.semis.core.designsystem.theme.surfaceTone
 
 /**
  * Tinted inline banner carrying a short contextual message about the current screen.
+ *
+ * Drawn as a soft fill with no outline, as the performance capture screen draws its own: an
+ * outline gives a remark the weight of a field waiting to be filled, and these are read in
+ * passing rather than acted on.
  */
 @Composable
 fun InlineNotice(
@@ -40,11 +42,6 @@ fun InlineNotice(
                 color = tone.surfaceTone(alpha = .12f),
                 shape = RoundedCornerShape(12.dp),
             )
-            .border(
-                width = 1.dp,
-                color = tone.borderTone(alpha = .35f),
-                shape = RoundedCornerShape(12.dp),
-            )
             .padding(horizontal = 12.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -53,15 +50,15 @@ fun InlineNotice(
             imageVector = imageVector,
             contentDescription = null,
             tint = tone,
-            modifier = Modifier.size(18.dp),
+            modifier = Modifier.size(20.dp),
         )
 
         Text(
             text = text,
             color = tone,
-            fontSize = 12.5.sp,
-            lineHeight = 17.sp,
-            fontFamily = FontFamily(Font(R.font.rubik_regular)),
+            fontSize = 13.5.sp,
+            lineHeight = 18.sp,
+            fontFamily = FontFamily(Font(R.font.rubik_medium)),
         )
     }
 }

--- a/semis/core/designsystem/src/main/res/values/strings.xml
+++ b/semis/core/designsystem/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="performance">Performance</string>
     <string name="performance_not_saved">You have unsaved performance changes. If you go back now, your data will be discarded.</string>
     <string name="performance_saved">Performance saved successfully</string>
-    <string name="cannot_take_attendance">Attendance cannot be taken on non-school days</string>
+    <string name="cannot_take_attendance">Please select a valid school day to continue!</string>
     <string name="semis_new_enrollment">New enrollment</string>
     <string name="save_enrollment">Save enrollment</string>
     <string name="enrollment_saved">Enrollment saved successfully</string>


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-155).

Presentation only. Nothing about how attendance works was touched: the counters, the state, the view model and the repository are as they were, and only what is drawn has moved.

### Problem

Attendance built a header of its own instead of taking the one the shared scaffold gives every other screen. It used a different blue, its own title and subtitle sizes, and its own placing and spacing of the actions, so moving from the home into attendance read as moving between two applications. The class the screen is scoped to was stated in a four column strip no other screen uses, and the counters sat inside the coloured band rather than on the sheet below it.

The notices were drawn with an outline, which gives a remark the weight of a field waiting to be filled, when they are read in passing rather than acted on.

### Solution

- Take the shared toolbar, with its colour, its title and its placing of the actions.
- Order the toolbar actions with the calendar after the sync, leaving the filter as the rightmost action wherever it appears. Attendance is the only screen showing a calendar, so nothing else moves.
- State the class and the tally on a sheet below the bar, laid out as the performance capture screen lays out its own: the school where performance names the subject, the class and the year beneath it, then the counters.
- Keep the counters in the colour of the status they count, unlike performance where the numbers are neutral. Presence and absence are read at a glance and losing that costs more than the calm it buys.
- Paint the colour behind the sheet's curve with the colour the bar itself uses. Two blues meeting there show as a band, which is how the first attempt at this looked.
- Draw the inline notice as a soft fill with no outline.
- Reword the notices: a day with no records asks for attendance to be taken, a finished day says it is completed, and a day outside the calendar asks for a valid school day.

### A defect found along the way

The tonal icon button set its tint on the button itself, and a button of that size is widened to stay comfortable to tap, so what was painted covered the wider area rather than the size asked for. Two of them side by side had their tints meet and read as one broken control, even with space between them. Measured on the device, the nodes were 69px apart while their tints touched.

It is now painted inside, on a box of the size given. This is its own commit, and it also shows on the attendance save bar and the transfer decisions, which use the same button.

### Reach beyond attendance

Two changes touch shared components on purpose:

- the button correction improves the attendance save bar and the transfer decisions
- the notice change also alters the student profile, which draws its empty state with the same banner

Both follow from using what is shared rather than what is local.

### Validation

- Unit test sweep over the touched modules: passing, unchanged. There are no new tests: the change is what is drawn, and the project has no screenshot testing to hold it.
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- Checked on the emulator at each step, including sampling the pixels along the seam between the bar and the sheet to confirm a single tone rather than two.