### PR TITLE
fix: [SEMIS-156] learner attendance events are written without the configured class context

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -315,6 +315,7 @@ class AttendanceViewModel @Inject constructor(
 
             runCatching {
                 formRepository.saveAttendance(
+                    orgUnit = current.formBuilderState.orgUnit,
                     program = current.program,
                     programStage = attendanceConfig?.programStage.orEmpty(),
                     attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents,

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -317,7 +317,13 @@ class AttendanceViewModel @Inject constructor(
                 formRepository.saveAttendance(
                     program = current.program,
                     programStage = attendanceConfig?.programStage.orEmpty(),
-                    attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents
+                    attendanceEvents = formRepository.attendanceButtonStateFlow.value.attendanceEvents,
+                    // The same values the class event carries, so a report built from the learner
+                    // records and the totals held on the class event cannot disagree.
+                    contextValues = attendanceRepository.classContextValues(
+                        program = current.program,
+                        filterDetailsState = current.attendanceSummaryState.filterDetailsState,
+                    ),
                 )
                 if (current.allowAttendanceStatus) {
                     attendanceRepository.completeAttendanceStatus(

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/AttendanceViewModel.kt
@@ -170,6 +170,7 @@ class AttendanceViewModel @Inject constructor(
 
         val currentButtonState = formRepository.loadAttendanceEvents(
             teiUids = studentsIds,
+            orgUnit = uiState.value.formBuilderState.orgUnit,
             program = uiState.value.program,
             programStage = attendanceConfig?.programStage.orEmpty(),
             dataElement = attendanceConfig?.status.orEmpty(),

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepository.kt
@@ -35,6 +35,18 @@ interface AttendanceRepository {
         attendanceEvents: List<AttendanceEventWithDecorator>,
     ): AttendanceStatus?
 
+    /**
+     * The configured filter values that say which class a record belongs to.
+     *
+     * The same values are written on the class event and on each learner event, so that a report
+     * built from the learner stage and the totals held on the class event cannot disagree. Which
+     * values these are comes from the configuration, not from this code.
+     */
+    suspend fun classContextValues(
+        program: String,
+        filterDetailsState: FilterDetailsState,
+    ): List<Pair<String, String>>
+
     suspend fun getAttendanceStatus(
         orgUnit: String,
         program: String,

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -181,6 +181,11 @@ class AttendanceRepositoryImpl(
         )
     }
 
+    override suspend fun classContextValues(
+        program: String,
+        filterDetailsState: FilterDetailsState,
+    ): List<Pair<String, String>> = contextValues(program, filterDetailsState)
+
     private suspend fun contextValues(
         program: String,
         filterDetailsState: FilterDetailsState,

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/AttendanceResetTest.kt
@@ -45,7 +45,7 @@ class AttendanceResetTest {
         formRepository.stub {
             on { attendanceButtonStateFlow } doReturn MutableStateFlow(AttendanceButtonState())
             onBlocking {
-                loadAttendanceEvents(any(), any(), any(), any(), any(), anyOrNull())
+                loadAttendanceEvents(any(), any(), any(), any(), any(), any(), anyOrNull())
             } doReturn AttendanceButtonState()
             onBlocking { deleteAttendance(any()) } doReturn AttendanceButtonState()
         }

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/ContextValues.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/model/ContextValues.kt
@@ -1,0 +1,25 @@
+package org.saudigitus.semis.core.data.model
+
+/**
+ * The context an event can actually carry, out of what it was offered.
+ *
+ * The values that say which class a record belongs to are whatever the configuration declares as
+ * filters, and a program stage may hold data elements for all of them, for some, or for none. Only
+ * what the stage holds is written, so a stage configured without them is left alone rather than
+ * refused, and a stage that gains one later starts carrying it without a change here.
+ *
+ * @param stageDataElements the data elements the program stage is configured with
+ * @param contextValues the configured context of the class, as data element to value
+ */
+fun contextValuesHeldBy(
+    stageDataElements: Collection<String>,
+    contextValues: List<Pair<String, String>>,
+): List<Pair<String, String>> {
+    if (stageDataElements.isEmpty() || contextValues.isEmpty()) return emptyList()
+
+    val held = stageDataElements.toSet()
+
+    return contextValues.filter { (dataElement, value) ->
+        dataElement in held && dataElement.isNotBlank() && value.isNotBlank()
+    }
+}

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
@@ -56,6 +56,10 @@ interface EventRepository {
      *
      * @param eventDate The date when the event occurred. If `null`, the current date will be used.
      */
+    /**
+     * @param contextValues the configured values saying which class the record belongs to. Only
+     * those the program stage actually holds are written, so a stage without them is unaffected.
+     */
     suspend fun saveEvent(
         event: String?,
         orgUnit: String,
@@ -64,6 +68,7 @@ interface EventRepository {
         tei: SearchTeiModel? = null,
         data: Map<String, Pair<String, String>>,
         eventDate: String? = null,
+        contextValues: List<Pair<String, String>> = emptyList(),
     )
 
     suspend fun saveEvent(

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepository.kt
@@ -83,6 +83,7 @@ interface EventRepository {
 
     suspend fun getEvents(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         eventDate: String?

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -253,6 +253,7 @@ class EventRepositoryImpl @Inject constructor(
 
     override suspend fun getEvents(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         eventDate: String?
@@ -265,6 +266,7 @@ class EventRepositoryImpl @Inject constructor(
 
         d2.eventModule().events()
             .byTrackedEntityInstanceUids(teiUids)
+            .byOrganisationUnitUid().eq(orgUnit)
             .byProgramUid().eq(program)
             .byProgramStageUid().eq(programStage)
             .byDeleted().isFalse

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -108,8 +108,15 @@ class EventRepositoryImpl @Inject constructor(
         uid
     }
 
+    /**
+     * The record a save should update instead of creating a new one, scoped to the school doing
+     * the saving. Without the school in the match, a save for a transferred learner would pick up
+     * the record their previous school wrote for the same day and stage, and the update would
+     * belong to a school the user cannot write into.
+     */
     private fun eventUid(
         tei: String?,
+        orgUnit: String,
         program: String,
         programStage: String,
         date: String?,
@@ -119,6 +126,7 @@ class EventRepositoryImpl @Inject constructor(
         return if (!tei.isNullOrEmpty()) {
             eventsRepo
             .byTrackedEntityInstanceUids(listOf(tei))
+                .byOrganisationUnitUid().eq(orgUnit)
                 .byProgramUid().eq(program)
                 .byProgramStageUid().eq(programStage)
                 .byDeleted().isFalse
@@ -126,6 +134,7 @@ class EventRepositoryImpl @Inject constructor(
                 .one().blockingGet()?.uid()
         } else {
             eventsRepo
+                .byOrganisationUnitUid().eq(orgUnit)
                 .byProgramUid().eq(program)
                 .byProgramStageUid().eq(programStage)
                 .byDeleted().isFalse
@@ -150,6 +159,7 @@ class EventRepositoryImpl @Inject constructor(
             try {
                 val uid = event ?: eventUid(
                     tei?.uid(),
+                    orgUnit,
                     program,
                     programStage,
                     date
@@ -215,6 +225,7 @@ class EventRepositoryImpl @Inject constructor(
             try {
                 val uid = event ?: eventUid(
                     tei?.uid(),
+                    orgUnit,
                     program,
                     programStage,
                     date

--- a/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
+++ b/semis/core/data/src/main/java/org/saudigitus/semis/core/data/repository/EventRepositoryImpl.kt
@@ -7,6 +7,7 @@ import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.core.data.model.SearchTeiModel
+import org.saudigitus.semis.core.data.model.contextValuesHeldBy
 import org.saudigitus.semis.core.utils.Constants
 import org.saudigitus.semis.core.utils.DateHelper
 import timber.log.Timber
@@ -140,7 +141,8 @@ class EventRepositoryImpl @Inject constructor(
         programStage: String,
         tei: SearchTeiModel?,
         data: Map<String, Pair<String, String>>,
-        eventDate: String?
+        eventDate: String?,
+        contextValues: List<Pair<String, String>>
     ) {
         withContext(Dispatchers.IO) {
             val date = eventDate ?: DateHelper.formatDate(System.currentTimeMillis())!!
@@ -171,6 +173,17 @@ class EventRepositoryImpl @Inject constructor(
                         .blockingSet(secondaryDataValue.second.takeIf { it.isNotEmpty() })
                 }
 
+                // The class context is rewritten on every save, not only on the first, so that a
+                // record edited after the class was corrected does not keep the old one.
+                contextValuesHeldBy(
+                    stageDataElements = stageDataElements(programStage),
+                    contextValues = contextValues,
+                ).forEach { (dataElement, value) ->
+                    d2.trackedEntityModule().trackedEntityDataValues()
+                        .value(uid, dataElement)
+                        .blockingSet(value)
+                }
+
                 val repository = d2.eventModule().events().uid(uid)
                 repository.setEventDate(Date.valueOf(date))
                 repository.setStatus(EventStatus.COMPLETED)
@@ -179,6 +192,13 @@ class EventRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    /** The data elements a program stage is configured with. */
+    private fun stageDataElements(programStage: String): List<String> =
+        d2.programModule().programStageDataElements()
+            .byProgramStage().eq(programStage)
+            .blockingGet()
+            .mapNotNull { it.dataElement()?.uid() }
 
     override suspend fun saveEvent(
         event: String?,

--- a/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/ContextValuesTest.kt
+++ b/semis/core/data/src/test/java/org/saudigitus/semis/core/data/model/ContextValuesTest.kt
@@ -1,0 +1,62 @@
+package org.saudigitus.semis.core.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContextValuesTest {
+
+    private val context = listOf(
+        "iDSrFrrVgmX" to "2025",
+        "kNNoif9gASf" to "Grade 1",
+        "RhABRLO2Fae" to "A",
+    )
+
+    @Test
+    fun `a stage holding every configured value carries them all`() {
+        val stage = listOf("d0MKWRNGv0a", "oLUMMT84ILM", "iDSrFrrVgmX", "kNNoif9gASf", "RhABRLO2Fae")
+
+        assertEquals(context, contextValuesHeldBy(stage, context))
+    }
+
+    @Test
+    fun `a stage holding some of them carries only those`() {
+        val stage = listOf("d0MKWRNGv0a", "kNNoif9gASf")
+
+        assertEquals(listOf("kNNoif9gASf" to "Grade 1"), contextValuesHeldBy(stage, context))
+    }
+
+    @Test
+    fun `a stage holding none of them is left alone`() {
+        val stage = listOf("d0MKWRNGv0a", "oLUMMT84ILM")
+
+        assertTrue(contextValuesHeldBy(stage, context).isEmpty())
+    }
+
+    @Test
+    fun `a stage with nothing configured is left alone`() {
+        assertTrue(contextValuesHeldBy(emptyList(), context).isEmpty())
+    }
+
+    @Test
+    fun `nothing configured as context writes nothing`() {
+        val stage = listOf("d0MKWRNGv0a", "iDSrFrrVgmX")
+
+        assertTrue(contextValuesHeldBy(stage, emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `a value that is blank is not written, since it says nothing`() {
+        val stage = listOf("iDSrFrrVgmX", "kNNoif9gASf")
+        val partial = listOf("iDSrFrrVgmX" to "2025", "kNNoif9gASf" to "")
+
+        assertEquals(listOf("iDSrFrrVgmX" to "2025"), contextValuesHeldBy(stage, partial))
+    }
+
+    @Test
+    fun `the order the configuration gives is kept`() {
+        val stage = listOf("RhABRLO2Fae", "kNNoif9gASf", "iDSrFrrVgmX")
+
+        assertEquals(context, contextValuesHeldBy(stage, context))
+    }
+}

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -12,11 +12,16 @@ interface AttendanceEventRepository {
     val attendanceButtonStateFlow: StateFlow<AttendanceButtonState>
 
     /**
+     * @param orgUnit the school of the class being marked, which is where every learner record is
+     * written. The learner's own registration unit is never used: after a transfer it names the
+     * school the learner came from, and a record written there belongs to somebody else and cannot
+     * even be sent by the school taking the attendance.
      * @param contextValues the configured values saying which class the records belong to, written
      * on each learner event where the stage holds them. What the app counts on the device does not
      * depend on them; they are stored so that a report built elsewhere can group by them.
      */
     suspend fun saveAttendance(
+        orgUnit: String,
         program: String,
         programStage: String,
         attendanceEvents: List<AttendanceEventWithDecorator>,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -39,6 +39,7 @@ interface AttendanceEventRepository {
 
     suspend fun getAttendanceEvent(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         dataElement: String,
@@ -65,6 +66,7 @@ interface AttendanceEventRepository {
 
     suspend fun loadAttendanceEvents(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         dataElement: String,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/AttendanceEventRepository.kt
@@ -11,10 +11,16 @@ interface AttendanceEventRepository {
 
     val attendanceButtonStateFlow: StateFlow<AttendanceButtonState>
 
+    /**
+     * @param contextValues the configured values saying which class the records belong to, written
+     * on each learner event where the stage holds them. What the app counts on the device does not
+     * depend on them; they are stored so that a report built elsewhere can group by them.
+     */
     suspend fun saveAttendance(
         program: String,
         programStage: String,
-        attendanceEvents: List<AttendanceEventWithDecorator>
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+        contextValues: List<Pair<String, String>> = emptyList(),
     )
 
     suspend fun saveAttendanceStatus(

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -204,6 +204,7 @@ class FormRepositoryImpl @Inject constructor(
 
     override suspend fun loadAttendanceEvents(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         dataElement: String,
@@ -215,6 +216,7 @@ class FormRepositoryImpl @Inject constructor(
 
         val attendanceEvents = getAttendanceEvent(
             teiUids = teiUids,
+            orgUnit = orgUnit,
             program = program,
             programStage = programStage,
             dataElement = attendanceConfig?.status.orEmpty(),
@@ -451,6 +453,7 @@ class FormRepositoryImpl @Inject constructor(
 
     override suspend fun getAttendanceEvent(
         teiUids: List<String>,
+        orgUnit: String,
         program: String,
         programStage: String,
         dataElement: String,
@@ -461,6 +464,7 @@ class FormRepositoryImpl @Inject constructor(
 
         eventRepository.getEvents(
             teiUids = teiUids,
+            orgUnit = orgUnit,
             program = program,
             programStage = programStage,
             eventDate = eventDate,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -393,6 +393,7 @@ class FormRepositoryImpl @Inject constructor(
     }
 
     override suspend fun saveAttendance(
+        orgUnit: String,
         program: String,
         programStage: String,
         attendanceEvents: List<AttendanceEventWithDecorator>,
@@ -410,7 +411,7 @@ class FormRepositoryImpl @Inject constructor(
         attendanceEvents.forEach { attendanceEvent ->
             eventRepository.saveEvent(
                 event = attendanceEvent.event?.event,
-                orgUnit = attendanceEvent.tei!!.tei.organisationUnit().orEmpty(),
+                orgUnit = orgUnit,
                 tei = attendanceEvent.tei!!,
                 program = program,
                 programStage = programStage,

--- a/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
+++ b/semis/core/form/src/main/java/org/saudigitus/semis/core/form/data/repository/impl/FormRepositoryImpl.kt
@@ -395,7 +395,8 @@ class FormRepositoryImpl @Inject constructor(
     override suspend fun saveAttendance(
         program: String,
         programStage: String,
-        attendanceEvents: List<AttendanceEventWithDecorator>
+        attendanceEvents: List<AttendanceEventWithDecorator>,
+        contextValues: List<Pair<String, String>>,
     ) = withContext(Dispatchers.IO) {
         // A learner dropped from the form no longer holds a status, so the record loaded
         // for them has to go with it rather than linger as a stale event.
@@ -423,7 +424,8 @@ class FormRepositoryImpl @Inject constructor(
                         attendanceEvent.event?.reasonOfAbsence.orEmpty()
                     ),
                 ),
-                eventDate = attendanceEvent.event?.date
+                eventDate = attendanceEvent.event?.date,
+                contextValues = contextValues,
             )
         }
     }


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-156).

### Problem

Attendance is written in two places: one event per absent learner on the learner stage, and one event per class holding the totals of the day. The class event carries the values of the configured filters, which is what says which class it belongs to. The learner events carried none of them.

That matters for the reporting side, which reports from the learner stage and cannot reach the class event to group by. The mobile app does not need these values and goes on counting exactly as it does today; it stores them so both clients write the same thing and a report cannot depend on which one recorded the day.

Measured on a test device: of 2972 learner attendance events, 12 carry the grade, 18 the section and 12 the academic year. The rest carry none, and those few had come from another client. The learner stage on the server already holds all three data elements, so the server was configured and waiting.

### Solution

- Write the configured context on each learner event, taken from the same place that fills the class event rather than computed a second time. The two cannot disagree, and a change to the configured filters moves both at once.
- Ask the program stage which of those data elements it holds and write only those. A stage holding none is left alone rather than refused, and a stage that gains one later starts carrying it with no change to the code. This is what keeps the feature from breaking where the configuration differs.
- Rewrite the context on every save, not only on creation, so a record edited after its class was corrected does not keep the old one.
- Put the stage check where the program stage can be read, so any other path writing an event inherits the same protection.

No identifier is named in code. The configuration decides which values these are, and the stage decides which of them are written.

### What does not change

The counting on the device. The totals, the summary of the day and the rule that a learner without a record is present are exactly as they were. This changes only what is stored.

The events already on the server stay as they are; rewriting that history is not the application's work.

### Validation

- Unit test sweep over the nine SEMIS modules: 100 tests, 0 failures, up from 93. The 7 new cases cover a stage holding every value, some of them, none, a stage with nothing configured, nothing configured as context, a blank value, and the order the configuration gives being kept.
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- On the emulator against the live server, an attendance recorded for 26 November 2025 at Albion LBS, Grade 1, section A produced a learner event carrying `d0MKWRNGv0a=absent` together with `iDSrFrrVgmX=2025`, `kNNoif9gASf=Grade 1` and `RhABRLO2Fae=A`. One recorded an hour earlier, before the change, reached the server with the status alone.