### PR TITLE
fix: [SEMIS-157] mitigation: choose the attendance summary of a day the same way every time

### DIFF
--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusChoice.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusChoice.kt
@@ -1,0 +1,47 @@
+package org.saudigitus.semis.attendance.ui.model
+
+import org.hisp.dhis.android.core.event.EventStatus
+
+/**
+ * One candidate for the attendance summary of a day, reduced to what deciding between them needs.
+ */
+internal data class AttendanceStatusCandidate<T>(
+    val event: T,
+    val status: EventStatus?,
+    val lastUpdated: Long,
+    val contextValues: List<Pair<String, String>>,
+)
+
+/**
+ * Picks the summary of a day out of the events that could be it.
+ *
+ * A day can hold more than one summary, because more than one client records attendance and
+ * nothing stops each creating its own. Taking whichever the query happens to return first means the
+ * same day can be answered two ways from one moment to the next, and the totals can be written onto
+ * whichever twin came up. The choice is therefore fixed here: the one already completed, and among
+ * equals the one most recently updated.
+ *
+ * This does not remove a duplicate, merge one, or stop another appearing. It makes the answer the
+ * same every time it is asked, which is all the app can do on its own.
+ *
+ * A candidate has to carry every value in [contextValues] to be considered at all. Where there is
+ * nothing to match on, nothing is chosen: two classes of the same school on the same day would then
+ * be indistinguishable, and picking one of them would be a guess written into the data.
+ */
+internal fun <T> chooseAttendanceStatus(
+    candidates: List<AttendanceStatusCandidate<T>>,
+    contextValues: List<Pair<String, String>>,
+): AttendanceStatusCandidate<T>? {
+    if (contextValues.isEmpty()) return null
+
+    return candidates
+        .filter { candidate -> candidate.carries(contextValues) }
+        .maxWithOrNull(
+            compareBy<AttendanceStatusCandidate<T>> { it.status == EventStatus.COMPLETED }
+                .thenBy { it.lastUpdated },
+        )
+}
+
+private fun <T> AttendanceStatusCandidate<T>.carries(
+    contextValues: List<Pair<String, String>>,
+): Boolean = contextValues.all { it in this.contextValues }

--- a/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
+++ b/semis/attendance/src/main/java/org/saudigitus/semis/attendance/ui/repository/AttendanceRepositoryImpl.kt
@@ -3,10 +3,11 @@ package org.saudigitus.semis.attendance.ui.repository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.hisp.dhis.android.core.D2
-import org.hisp.dhis.android.core.event.Event
 import org.hisp.dhis.android.core.event.EventCreateProjection
 import org.hisp.dhis.android.core.event.EventStatus
 import org.saudigitus.semis.attendance.ui.model.AttendanceStatus
+import org.saudigitus.semis.attendance.ui.model.AttendanceStatusCandidate
+import org.saudigitus.semis.attendance.ui.model.chooseAttendanceStatus
 import org.saudigitus.semis.attendance.ui.model.attendanceStatusSummaryValues
 import org.saudigitus.semis.attendance.ui.model.attendanceSummaryCounts
 import org.saudigitus.semis.attendance.ui.model.isPresent
@@ -162,7 +163,7 @@ class AttendanceRepositoryImpl(
         if (eventProgram.isEmpty() || programStage.isEmpty()) return@withContext null
 
         val contextValues = contextValues(program, filterDetailsState)
-        val event = d2.eventModule().events()
+        val candidates = d2.eventModule().events()
             .byOrganisationUnitUid().eq(orgUnit)
             .byProgramUid().eq(eventProgram)
             .byProgramStageUid().eq(programStage)
@@ -170,7 +171,20 @@ class AttendanceRepositoryImpl(
             .byDeleted().isFalse
             .withTrackedEntityDataValues()
             .blockingGet()
-            .firstOrNull { it.matches(contextValues) }
+            .map { event ->
+                AttendanceStatusCandidate(
+                    event = event,
+                    status = event.status(),
+                    lastUpdated = event.lastUpdated()?.time ?: 0L,
+                    contextValues = event.trackedEntityDataValues().orEmpty().mapNotNull {
+                        val dataElement = it.dataElement() ?: return@mapNotNull null
+                        val value = it.value() ?: return@mapNotNull null
+                        dataElement to value
+                    },
+                )
+            }
+
+        val event = chooseAttendanceStatus(candidates, contextValues)?.event
             ?: return@withContext null
 
         AttendanceStatus(
@@ -228,13 +242,6 @@ class AttendanceRepositoryImpl(
             counts = summaryCounts,
         )
     }
-
-    private fun Event.matches(contextValues: List<Pair<String, String>>) =
-        contextValues.all { (dataElement, value) ->
-            trackedEntityDataValues().orEmpty().any {
-                it.dataElement() == dataElement && it.value() == value
-            }
-        }
 
     private fun contextValue(dataElement: String?, value: String?): Pair<String, String>? =
         if (dataElement.isNullOrBlank() || value.isNullOrBlank()) {

--- a/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusChoiceTest.kt
+++ b/semis/attendance/src/test/java/org/saudigitus/semis/attendance/ui/model/AttendanceStatusChoiceTest.kt
@@ -1,0 +1,103 @@
+package org.saudigitus.semis.attendance.ui.model
+
+import org.hisp.dhis.android.core.event.EventStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AttendanceStatusChoiceTest {
+
+    private val context = listOf(
+        "iDSrFrrVgmX" to "2025",
+        "kNNoif9gASf" to "Grade 1",
+        "RhABRLO2Fae" to "A",
+    )
+
+    private fun candidate(
+        name: String,
+        status: EventStatus? = EventStatus.ACTIVE,
+        lastUpdated: Long = 0L,
+        values: List<Pair<String, String>> = context,
+    ) = AttendanceStatusCandidate(
+        event = name,
+        status = status,
+        lastUpdated = lastUpdated,
+        contextValues = values,
+    )
+
+    @Test
+    fun `the only candidate is the one chosen`() {
+        val only = candidate("only")
+
+        assertEquals("only", chooseAttendanceStatus(listOf(only), context)?.event)
+    }
+
+    @Test
+    fun `a completed day is preferred over one left open`() {
+        val open = candidate("open", status = EventStatus.ACTIVE, lastUpdated = 200)
+        val completed = candidate("completed", status = EventStatus.COMPLETED, lastUpdated = 100)
+
+        assertEquals("completed", chooseAttendanceStatus(listOf(open, completed), context)?.event)
+        assertEquals("completed", chooseAttendanceStatus(listOf(completed, open), context)?.event)
+    }
+
+    @Test
+    fun `among completed the most recently updated is chosen`() {
+        val older = candidate("older", status = EventStatus.COMPLETED, lastUpdated = 100)
+        val newer = candidate("newer", status = EventStatus.COMPLETED, lastUpdated = 300)
+
+        assertEquals("newer", chooseAttendanceStatus(listOf(older, newer), context)?.event)
+        assertEquals("newer", chooseAttendanceStatus(listOf(newer, older), context)?.event)
+    }
+
+    @Test
+    fun `among open days the most recently updated is chosen`() {
+        val older = candidate("older", lastUpdated = 100)
+        val newer = candidate("newer", lastUpdated = 300)
+
+        assertEquals("newer", chooseAttendanceStatus(listOf(older, newer), context)?.event)
+    }
+
+    @Test
+    fun `the order the candidates arrive in does not change the answer`() {
+        val a = candidate("a", status = EventStatus.COMPLETED, lastUpdated = 100)
+        val b = candidate("b", status = EventStatus.ACTIVE, lastUpdated = 900)
+        val c = candidate("c", status = EventStatus.COMPLETED, lastUpdated = 200)
+
+        val orders = listOf(listOf(a, b, c), listOf(c, b, a), listOf(b, a, c), listOf(b, c, a))
+
+        orders.forEach { order ->
+            assertEquals("c", chooseAttendanceStatus(order, context)?.event)
+        }
+    }
+
+    @Test
+    fun `a candidate of another class is not considered`() {
+        val otherClass = candidate(
+            "other",
+            values = listOf("iDSrFrrVgmX" to "2025", "kNNoif9gASf" to "Grade 1", "RhABRLO2Fae" to "B"),
+        )
+
+        assertNull(chooseAttendanceStatus(listOf(otherClass), context)?.event)
+    }
+
+    @Test
+    fun `a candidate carrying more than is asked for still counts`() {
+        val richer = candidate("richer", values = context + ("extra" to "value"))
+
+        assertEquals("richer", chooseAttendanceStatus(listOf(richer), context)?.event)
+    }
+
+    @Test
+    fun `with nothing to identify a class by, nothing is chosen`() {
+        val one = candidate("one", values = emptyList())
+        val two = candidate("two", values = emptyList())
+
+        assertNull(chooseAttendanceStatus(listOf(one, two), emptyList()))
+    }
+
+    @Test
+    fun `no candidates at all yields nothing`() {
+        assertNull(chooseAttendanceStatus(emptyList<AttendanceStatusCandidate<String>>(), context))
+    }
+}


### PR DESCRIPTION
## Description

Link the [JIRA issue](https://dhis2.atlassian.net/browse/SEMIS-157), also tracked as #54.

**This is mitigation, not a fix.** It does not remove a duplicate, merge one, or stop another appearing, and it does not close SEMIS-157. What would close it is a unique event date on the program stage, so that a stage cannot hold two events for the same day and subject at all. That is a system level change reaching the server and the other client, and it is what the ticket is about.

### Problem

A day can hold more than one attendance summary. Of 25 summaries on a test device, 17 are still open and 15 of those did not originate on that device: more than one client records attendance and nothing stops each creating its own.

The search for the summary of a day took whichever the query happened to return first, with no order asked for. The same day could therefore be answered two ways from one moment to the next: a finished day reported as still open, or the totals written onto whichever twin came up while the other kept its own numbers. Nothing was reported to the user either way.

A second fault sat alongside it. The comparison required every configured value to be present on the event, and answered true when there was nothing to compare. A program configured without those filters therefore accepted any summary of that day and school, including one belonging to another class.

### Solution

- Choose deterministically: prefer the summary already completed, and among equals the most recently updated. The order the candidates arrive in no longer changes the answer, so a finished day is never reported as open and the totals always land on the same event.
- Where there is nothing to identify a class by, choose nothing. Two classes of the same school on the same day would be indistinguishable, and picking one would be a guess written into the data.

The decision moved into a pure function taking the candidates and the context, which is what let it be covered case by case.

### Validation

- Unit test sweep over the nine SEMIS modules: 102 tests, 0 failures, up from 93. The 9 new cases cover a single candidate, completed preferred over open, the most recent among completed, the most recent among open, four different arrival orders giving the same answer, a candidate of another class, a candidate carrying more than was asked, nothing to identify a class by, and no candidates at all.
- `./gradlew assembleDhis2Debug`, what CI runs: BUILD SUCCESSFUL.
- Checked against the real duplicate on the server. 2025-11-03 at Albion LBS holds `y7UhymFfvrV`, completed, and `rbEsXTEkNRC`, open, both carrying the full context. Under this rule the completed one is chosen, every time.

### Not verified on the device

The day itself was not opened in the running app. Reaching it needs the class filters set, and the organisation unit picker does not respond to automation on this emulator. The rule is covered by the tests above, including order independence, and was checked against the actual stored candidates, but no one has watched the screen answer for that day.